### PR TITLE
Added secrets to terastore-db Action.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,9 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend-test, frontend-test]
     env:
-      POSTGRES_USER: pg_user
-      POSTGRES_PASSWORD: pg_user_pw
-      POSTGRES_DB: terastore-db
+      POSTGRES_USER: ${{ secrets.TERASTORE_DB_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.TERASTORE_DB_PASSWORD }}
+      POSTGRES_DB: ${{ secrets.TERASTORE_DB_NAME}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds the `POSTGRES_USER`, `POSTGRES_PASSWORD` and `POSTGRES_DB` as secret env vars for the `docker-test-build` Actions step.

Note I have added `POSTGRES_DB` as a secret. This may not be a secret per se, but I guess any information leakage is bad, and secrets don't cost us anything.