### PR TITLE
Prod does not create tables

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -7,19 +7,32 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.database import create_db_and_tables, drop_tables
 from api.public import make_api
 from api.utils.mock_data_generator import create_devices_and_pulses
-from api.utils.types import WithLifespan
+from api.utils.types import Lifespan
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def lifespan_dev(app: FastAPI) -> AsyncGenerator[None, None]:
     create_db_and_tables()
     create_devices_and_pulses()
     yield
     drop_tables()
 
 
-def create_app(with_lifespan: WithLifespan) -> FastAPI:
-    app = FastAPI(lifespan=lifespan) if with_lifespan.value else FastAPI()
+@asynccontextmanager
+async def lifespan_prod(app: FastAPI) -> AsyncGenerator[None, None]:
+    create_db_and_tables()
+    yield
+
+
+LIFESPAN_FUNCTIONS = {
+    Lifespan.PROD: lifespan_prod,
+    Lifespan.DEV: lifespan_dev,
+    Lifespan.TEST: lifespan_dev,
+}
+
+
+def create_app(lifespan: Lifespan) -> FastAPI:
+    app = FastAPI(lifespan=LIFESPAN_FUNCTIONS[lifespan])
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/backend/api/utils/types.py
+++ b/backend/api/utils/types.py
@@ -1,8 +1,9 @@
-from enum import Enum
+from enum import Enum, auto
 
 
-class WithLifespan(Enum):
+class Lifespan(Enum):
     """Enum for the lifespan argument of create_app."""
 
-    TRUE = True
-    FALSE = False
+    PROD = auto()
+    DEV = auto()
+    TEST = auto()

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -4,13 +4,15 @@ import uvicorn
 
 from api.config import get_settings
 from api.main import create_app
-from api.utils.types import WithLifespan
+from api.utils.types import Lifespan
 
 parser = argparse.ArgumentParser(description="Start the FastAPI application.")
+
 parser.add_argument(
-    "--with-lifespan",
-    action="store_true",
-    help="Run the lifespan function on startup.",
+    "--lifespan",
+    choices=[lifespan.name for lifespan in Lifespan],
+    help="Run the application with the lifespan PROD, DEV or TEST.",
+    required=True,
 )
 parser.add_argument(
     "--with-reload",
@@ -19,10 +21,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.with_lifespan:
-    api = create_app(WithLifespan.TRUE)
-else:
-    api = create_app(WithLifespan.FALSE)
+api = create_app(Lifespan[args.lifespan])
 
 
 if __name__ == "__main__":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, create_engine
 from api.config import get_settings
 from api.database import create_db_and_tables, drop_tables, get_session
 from api.main import create_app
-from api.utils.types import WithLifespan
+from api.utils.types import Lifespan
 
 
 @pytest.fixture(name="session")
@@ -26,7 +26,7 @@ def session_fixture() -> Generator[Session, None, None]:
 @pytest.fixture(name="client")
 def client_fixture(session: Session) -> Generator[TestClient, None, None]:
     """Create a TestClient instance for testing."""
-    app = create_app(WithLifespan.FALSE)
+    app = create_app(Lifespan.TEST)
 
     def get_session_override() -> Session:
         return session

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile.backend.dev
     container_name: terastore-backend-dev
-    command: python asgi.py --with-lifespan --with-reload
+    command: python asgi.py --with-lifespan DEV --with-reload
     environment:
       - "DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db-dev/${POSTGRES_DB}"
       - ENV=${ENV}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: ./backend
       dockerfile: ../docker/Dockerfile.backend
     container_name: terastore-backend
-    command: python asgi.py
+    command: python asgi.py --with-lifespan PROD
     environment:
       - "DATABASE_URL=postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}"
       - ENV=${ENV}


### PR DESCRIPTION
To create tables, `SQLModel` has to run `SQLModel.metadata.create_all()`. This was only done for dev and test envs, not for prod.

I have added two distinct FastAPI `lifespan` functions. Which one is run, is chosen by the user when invoking `python asgi.py`, where `--lifespan` must be set to either `PROD`, `DEV` or `TEST`. I want this to be required, so the behaviour of the app is deterministic.

`DEV` and `TEST` use the same `lifespan` function for now, but might not in the future.