### PR TITLE
35 Selectable pulses

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { Pulse } from "classes";
 import { PulseFilter } from "interfaces";
 const api = axios.create({
 	baseURL: import.meta.env.PROD
@@ -29,5 +30,17 @@ export async function getFilteredPulses(
 ): Promise<string[]> {
 	return api.post("/attrs/filter", filters).then((resp) => {
 		return resp.data;
+	});
+}
+
+export async function getPulse(pulseID: string): Promise<Pulse> {
+	return api.get(`/pulses/${pulseID}`).then((resp) => {
+		return new Pulse(
+			resp.data.delays,
+			resp.data.signal,
+			resp.data.integration_time,
+			new Date(resp.data.creation_time),
+			resp.data.pulse_id,
+		);
 	});
 }

--- a/frontend/src/classes/index.ts
+++ b/frontend/src/classes/index.ts
@@ -11,3 +11,13 @@ export class FilterResult {
 		return this.filters[this.filters.length - 1];
 	}
 }
+
+export class Pulse {
+	constructor(
+		public time: number[],
+		public signal: number[],
+		public integrationTime: number,
+		public creationTime: Date,
+		public ID: string,
+	) {}
+}

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -14,15 +14,20 @@ function App() {
 
 	return (
 		<MantineProvider defaultColorScheme="auto">
-			<AppShell navbar={{ width: 200, breakpoint: "xs" }}>
+			<AppShell
+				navbar={{ width: 250, breakpoint: "xs" }}
+				aside={{ width: 250, breakpoint: "xs" }}
+			>
 				<AppShell.Header> </AppShell.Header>
 				<AppShell.Navbar>
 					<FilterMenu />
 				</AppShell.Navbar>
 				<AppShell.Main>
-					<MatchingPulses />
 					<RecommendedFilters />
 				</AppShell.Main>
+				<AppShell.Aside>
+					<MatchingPulses />
+				</AppShell.Aside>
 			</AppShell>
 		</MantineProvider>
 	);

--- a/frontend/src/components/MatchingPulses.tsx
+++ b/frontend/src/components/MatchingPulses.tsx
@@ -1,19 +1,92 @@
 import * as M from "@mantine/core";
-import { getFilteredPulses } from "api";
+import { getFilteredPulses, getPulse } from "api";
+import { Pulse } from "classes";
 import { useEffect, useState } from "react";
 import { useFiltersStore } from "store";
+interface PulseCardProps {
+	pulseID: string;
+	isSelected: boolean;
+	setSelected: (value: React.SetStateAction<string | null>) => void;
+}
+
+function PulseCard({ pulseID, isSelected, setSelected }: PulseCardProps) {
+	const [pulse, setPulse] = useState<Pulse | null>(null);
+
+	useEffect(() => {
+		if (isSelected) {
+			getPulse(pulseID).then((p) => setPulse(p));
+		}
+	}, [isSelected]);
+
+	return (
+		<M.Popover
+			opened={isSelected}
+			position="left-start"
+			offset={10}
+			withArrow
+			arrowSize={10}
+		>
+			<M.Popover.Target>
+				<M.Card
+					shadow="xs"
+					radius="md"
+					p={5}
+					m={5}
+					onClick={() =>
+						isSelected ? setSelected(null) : setSelected(pulseID)
+					}
+					style={{
+						backgroundColor: isSelected
+							? "var(--mantine-color-blue-1)"
+							: undefined,
+					}}
+				>
+					<M.Text lineClamp={1}>{pulseID}</M.Text>
+				</M.Card>
+			</M.Popover.Target>
+			<M.Popover.Dropdown>
+				<M.Text>Datapoints: {pulse?.time.length}</M.Text>
+				<M.Text>Integration Time: {pulse?.integrationTime} ms</M.Text>
+				<M.Text>
+					Creation Time: {pulse?.creationTime.toLocaleDateString("en-GB")}
+				</M.Text>
+			</M.Popover.Dropdown>
+		</M.Popover>
+	);
+}
+
 function MatchingPulses() {
-	const [nPulses, setNPulses] = useState<number | null>(null);
+	const [filteredPulses, setFilteredPulses] = useState<string[] | null>(null);
+	const [selectedItem, setSelectedItem] = useState<string | null>(null);
 	const [pulseFilters] = useFiltersStore((state) => [state.pulseFilters]);
 
 	useEffect(() => {
-		getFilteredPulses(pulseFilters).then((res) => setNPulses(res.length));
+		getFilteredPulses(pulseFilters).then((res) => setFilteredPulses(res));
 	}, [pulseFilters]);
 
 	return (
-		<M.Text fw={700} p={10} size="lg">
-			Matching pulses: {nPulses}
-		</M.Text>
+		<>
+			<M.Stack p={10}>
+				<M.Text fw={700} size="lg">
+					Matching pulses: {filteredPulses?.length}
+				</M.Text>
+				<M.Button onClick={() => console.log("Not implemented yet")}>
+					Download
+				</M.Button>
+			</M.Stack>
+
+			<M.Divider ml={10} mr={10} />
+			<M.ScrollArea type="hover">
+				{filteredPulses?.map((pulseID) => (
+					<PulseCard
+						pulseID={pulseID}
+						isSelected={pulseID === selectedItem}
+						setSelected={setSelectedItem}
+						key={pulseID}
+					/>
+				))}
+			</M.ScrollArea>
+		</>
 	);
 }
 

--- a/frontend/src/components/MatchingPulses.tsx
+++ b/frontend/src/components/MatchingPulses.tsx
@@ -3,6 +3,7 @@ import { getFilteredPulses, getPulse } from "api";
 import { Pulse } from "classes";
 import { useEffect, useState } from "react";
 import { useFiltersStore } from "store";
+
 interface PulseCardProps {
 	pulseID: string;
 	isSelected: boolean;


### PR DESCRIPTION
Adds an aside, which displays the pulses, a filtering matches. Pulses can be clicked to inspect metadata on the pulse. Additionally, a proposed placement for a "Download"-button has been added, which for now doesn't have any functionality

Closes #35 