### PR TITLE
Stop loggin health check pings in backend

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -6,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.database import create_db_and_tables, drop_tables
 from api.public import make_api
+from api.utils.logging import EndpointFilter
 from api.utils.mock_data_generator import (
     create_devices_and_pulses,
     create_frontend_dev_data,
@@ -43,6 +45,9 @@ def create_app(lifespan: Lifespan) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    uvicorn_logger = logging.getLogger("uvicorn.access")
+    uvicorn_logger.addFilter(EndpointFilter(path="/health"))
 
     @app.get("/")
     async def root() -> dict[str, str]:

--- a/backend/api/utils/logging.py
+++ b/backend/api/utils/logging.py
@@ -1,0 +1,11 @@
+import logging
+from typing import Self
+
+
+class EndpointFilter(logging.Filter):
+    def __init__(self: Self, path: str) -> None:
+        super().__init__()
+        self._path = path
+
+    def filter(self: Self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find(self._path) == -1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -65,6 +65,7 @@ ignore = [
   "D103", # allow undocumented public function
   "D104", # allow undocumented public package
   "D106", # allow undocumented public nested class
+  "D107", # allow undocumented public __init__
   "D203", # allow 0 black lines before class docstring
   "D213", # allow multiline docstring to start on first line
 ]


### PR DESCRIPTION
This PR stops logging health checks (i.e. requests to the "/health" route).

Read linked issue #60 to understand thinking behind this. I've opted to just not log the requests, because that solution is easiest.

I have added an excluded Ruff rule as well, pertaining to docstrings in `__init__()` functions.