### PR TITLE
Enable dev and test Docker Compose services to run at the same time

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -12,7 +12,7 @@ services:
       - ./backend:/app
       - ./scripts:/scripts
     ports:
-      - 8000:8000
+      - 8001:8000
     depends_on:
       db-test:
         condition: service_healthy
@@ -31,7 +31,7 @@ services:
     restart: always
     container_name: terastore-postgres-test
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - db:/var/lib/postgresql/data
 


### PR DESCRIPTION
See issue #62 for explanation.

Closes #62 .