### PR TITLE
Change database index to be autoincrementing int

### DIFF
--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from fastapi import Depends
 from sqlalchemy import and_
 from sqlmodel import Session, select
@@ -10,7 +8,7 @@ from api.public.pulse.models import Pulse
 
 
 def add_str_attr(
-    pulse_id: UUID,
+    pulse_id: int,
     key: str,
     value: str,
     db: Session = Depends(get_session),
@@ -39,7 +37,7 @@ def add_str_attr(
 
 
 def read_pulse_attrs(
-    pulse_id: UUID,
+    pulse_id: int,
     db: Session = Depends(get_session),
 ) -> list[dict[str, str]] | None:
     """Get all the keys for a pulse with id pulse_id."""
@@ -74,7 +72,7 @@ def read_all_values_on_key(
 def filter_on_key_value_pairs(
     key_value_pairs: list[dict[str, str]],
     db: Session = Depends(get_session),
-) -> list[UUID]:
+) -> list[int]:
     """Get all pulses that match the key-value pairs."""
     # Initialize a list to hold pulse_ids for each condition
     pulse_ids_list = []

--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from sqlmodel import Field, SQLModel
 
 
@@ -10,7 +8,7 @@ class PulseStrAttrs(SQLModel, table=True):
 
     key: str
     value: str
-    pulse_id: UUID = Field(foreign_key="pulses.pulse_id", index=True)
+    pulse_id: int = Field(foreign_key="pulses.pulse_id", index=True)
 
     index: int | None = Field(default=None, primary_key=True)
 
@@ -20,4 +18,6 @@ class PulseKeyRegistry(SQLModel, table=True):
 
     __tablename__ = "pulse_key_registry"
 
-    key: str = Field(primary_key=True)
+    key: str
+
+    index: int | None = Field(default=None, primary_key=True)

--- a/backend/api/public/attrs/views.py
+++ b/backend/api/public/attrs/views.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
@@ -27,7 +25,7 @@ def get_all_values_on_key(key: str, db: Session = Depends(get_session)) -> list[
 def filter_attrs(
     key_value_pairs: list[dict[str, str]],
     db: Session = Depends(get_session),
-) -> list[UUID]:
+) -> list[int]:
     """Filter pulses based on key-value pairs.
 
     Example usage:

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -2,18 +2,18 @@ from fastapi import Depends
 from sqlmodel import Session, select
 
 from api.database import get_session
-from api.public.device.models import Device, DeviceCreate
+from api.public.device.models import Device, DeviceCreate, DeviceRead
 
 
 def create_device(
     device: DeviceCreate,
     db: Session = Depends(get_session),
-) -> Device:
+) -> DeviceRead:
     device_to_db = Device.from_orm(device)
     db.add(device_to_db)
     db.commit()
     db.refresh(device_to_db)
-    return device_to_db
+    return DeviceRead.from_orm(device_to_db)
 
 
 def read_devices(

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from fastapi import Depends
 from sqlmodel import Session, select
 
@@ -26,5 +24,5 @@ def read_devices(
     return db.exec(select(Device).offset(offset).limit(limit)).all()
 
 
-def read_device(device_id: UUID, db: Session = Depends(get_session)) -> Device | None:
+def read_device(device_id: int, db: Session = Depends(get_session)) -> Device | None:
     return db.get(Device, device_id)

--- a/backend/api/public/device/models.py
+++ b/backend/api/public/device/models.py
@@ -24,7 +24,7 @@ class Device(DeviceBase, table=True):
 
     __tablename__ = "devices"
 
-    device_id: int = Field(default=None, primary_key=True)
+    device_id: int | None = Field(default=None, primary_key=True)
 
 
 class DeviceCreate(DeviceBase):

--- a/backend/api/public/device/models.py
+++ b/backend/api/public/device/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Self
-from uuid import UUID, uuid4
 
 from sqlmodel import Field, SQLModel
 
@@ -25,7 +24,7 @@ class Device(DeviceBase, table=True):
 
     __tablename__ = "devices"
 
-    device_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    device_id: int = Field(default=None, primary_key=True)
 
 
 class DeviceCreate(DeviceBase):
@@ -53,4 +52,4 @@ class DeviceRead(DeviceBase):
     from the db, as this requires the device_id.
     """
 
-    device_id: UUID
+    device_id: int

--- a/backend/api/public/device/views.py
+++ b/backend/api/public/device/views.py
@@ -12,7 +12,7 @@ router = APIRouter()
 def create_a_device(
     device: DeviceCreate,
     db: Session = Depends(get_session),
-) -> Device:
+) -> DeviceRead:
     return create_device(device=device, db=db)
 
 

--- a/backend/api/public/device/views.py
+++ b/backend/api/public/device/views.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlmodel import Session
 
@@ -28,7 +26,7 @@ def get_devices(
 
 
 @router.get("/{device_id}", response_model=DeviceRead)
-def get_device(device_id: UUID, db: Session = Depends(get_session)) -> Device:
+def get_device(device_id: int, db: Session = Depends(get_session)) -> Device:
     device = read_device(device_id=device_id, db=db)
 
     if not device:

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -1,19 +1,17 @@
-from uuid import UUID
-
 from fastapi import Depends
 from sqlmodel import Session, select
 
 from api.database import get_session
-from api.public.pulse.models import Pulse, PulseCreate, TemporaryPulseIdTable
+from api.public.pulse.models import Pulse, PulseCreate, PulseRead, TemporaryPulseIdTable
 
 
-def create_pulse(pulse: PulseCreate, db: Session = Depends(get_session)) -> Pulse:
+def create_pulse(pulse: PulseCreate, db: Session = Depends(get_session)) -> PulseRead:
     pulse_to_db = Pulse.from_orm(pulse)
 
     db.add(pulse_to_db)
     db.commit()
     db.refresh(pulse_to_db)
-    return pulse_to_db
+    return PulseRead.from_orm(pulse_to_db)
 
 
 def read_pulses(
@@ -26,7 +24,7 @@ def read_pulses(
 
 
 def read_pulses_with_ids(
-    ids: list[UUID],
+    ids: list[int],
     db: Session = Depends(get_session),
 ) -> list[Pulse]:
     # Save wanted ID's in a temporary table
@@ -48,5 +46,5 @@ def read_pulses_with_ids(
     return pulses
 
 
-def read_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> Pulse | None:
+def read_pulse(pulse_id: int, db: Session = Depends(get_session)) -> Pulse | None:
     return db.get(Pulse, pulse_id)

--- a/backend/api/public/pulse/models.py
+++ b/backend/api/public/pulse/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TCH003
 from typing import TYPE_CHECKING, Self
-from uuid import UUID, uuid4
 
 from sqlalchemy.dialects import postgresql
 from sqlmodel import Column, Field, Float, SQLModel
@@ -38,7 +37,7 @@ class PulseBase(SQLModel):
     signal: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
     integration_time: int
     creation_time: datetime
-    device_id: UUID = Field(foreign_key="devices.device_id")
+    device_id: int = Field(foreign_key="devices.device_id")
 
 
 class Pulse(PulseBase, table=True):
@@ -49,7 +48,7 @@ class Pulse(PulseBase, table=True):
 
     __tablename__ = "pulses"
 
-    pulse_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    pulse_id: int | None = Field(default=None, primary_key=True)
 
 
 class PulseCreate(PulseBase):
@@ -62,7 +61,7 @@ class PulseCreate(PulseBase):
     @classmethod
     def create_mock(
         cls: type[PulseCreate],
-        device_id: UUID,
+        device_id: int,
         length: int = 600,
         timescale: float = 1e-10,
         amplitude: float = 100.0,
@@ -75,7 +74,7 @@ class PulseCreate(PulseBase):
             device_id=device_id,
         )
 
-    def as_dict(self: Self) -> dict[str, list[float] | int | str | UUID]:
+    def as_dict(self: Self) -> dict[str, list[float] | int | str]:
         return {
             "delays": self.delays,
             "signal": self.signal,
@@ -92,7 +91,7 @@ class PulseRead(PulseBase):
     from the db, as this requires the pulse_id.
     """
 
-    pulse_id: UUID
+    pulse_id: int
 
 
 class PulseReadWithDevice(PulseRead):
@@ -112,4 +111,4 @@ class TemporaryPulseIdTable(SQLModel, table=True):
 
     __tablename__ = "temporary_pulse_id_table"
 
-    pulse_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    pulse_id: int = Field(default=None, primary_key=True)

--- a/backend/api/public/pulse/views.py
+++ b/backend/api/public/pulse/views.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from psycopg2.errors import ForeignKeyViolation
 from sqlalchemy.exc import DBAPIError
@@ -22,7 +20,7 @@ router = APIRouter()
 def create_a_pulse(
     pulse: PulseCreate,
     db: Session = Depends(get_session),
-) -> Pulse:
+) -> PulseRead:
     try:
         return create_pulse(pulse=pulse, db=db)
     except DBAPIError as e:
@@ -45,14 +43,14 @@ def get_pulses(
 
 @router.post("/get", response_model=list[PulseRead])
 def get_pulses_from_ids(
-    ids: list[UUID],
+    ids: list[int],
     db: Session = Depends(get_session),
 ) -> list[Pulse]:
     return read_pulses_with_ids(ids, db=db)
 
 
 @router.get("/{pulse_id}", response_model=PulseRead)
-def get_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> Pulse:
+def get_pulse(pulse_id: int, db: Session = Depends(get_session)) -> Pulse:
     pulse = read_pulse(pulse_id=pulse_id, db=db)
     if not pulse:
         raise HTTPException(
@@ -64,7 +62,7 @@ def get_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> Pulse:
 
 @router.put("/{pulse_id}/attrs", response_model=PulseRead)
 def add_kv_str(
-    pulse_id: UUID,
+    pulse_id: int,
     key: str,
     value: str,
     db: Session = Depends(get_session),
@@ -80,7 +78,7 @@ def add_kv_str(
 
 @router.get("/{pulse_id}/attrs")
 def get_pulse_keys(
-    pulse_id: UUID,
+    pulse_id: int,
     db: Session = Depends(get_session),
 ) -> list[dict[str, str]]:
     pulse_attrs = read_pulse_attrs(pulse_id=pulse_id, db=db)

--- a/backend/api/utils/helpers.py
+++ b/backend/api/utils/helpers.py
@@ -1,6 +1,5 @@
 import secrets
 from datetime import datetime
-from uuid import UUID
 from zoneinfo import ZoneInfo
 
 
@@ -27,11 +26,11 @@ def get_now(timezone: str = "Europe/Copenhagen") -> datetime:
 
 
 def create_mock_pulse(
-    device_id: UUID,
+    device_id: int,
     length: int = 600,
     timescale: float = 1e-10,
     amplitude: float = 100.0,
-) -> dict[str, list[float] | int | datetime | UUID]:
+) -> dict[str, list[float] | int | datetime]:
     return {
         "delays": generate_scaled_numbers(length, timescale),
         "signal": generate_random_numbers(length, -amplitude, amplitude),

--- a/backend/tests/api/public/attrs/test_views.py
+++ b/backend/tests/api/public/attrs/test_views.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 from fastapi.testclient import TestClient
 
 from api.utils.mock_data_generator import create_devices_and_pulses
@@ -72,7 +70,7 @@ def test_get_attrs_on_pulse(client: TestClient, device_uuid: str) -> None:
 
 
 def test_get_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
-    pulse_id = str(uuid4())
+    pulse_id = 1000
     response = client.get(f"/pulses/{pulse_id}/attrs/")
 
     assert response.status_code == 404
@@ -109,7 +107,7 @@ def test_add_pulse_attrs_on_pulse(client: TestClient, device_uuid: str) -> None:
 
 
 def test_add_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
-    pulse_id = str(uuid4())
+    pulse_id = 1000
     attrs_key = "angle"
     attrs_value = "29"
 

--- a/backend/tests/api/public/attrs/test_views.py
+++ b/backend/tests/api/public/attrs/test_views.py
@@ -30,9 +30,9 @@ def test_get_all_values_on_non_existing_key(client: TestClient) -> None:
     assert response.json() == []
 
 
-def test_get_attrs_on_pulse(client: TestClient, device_uuid: str) -> None:
+def test_get_attrs_on_pulse(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -77,9 +77,9 @@ def test_get_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
     assert response.json()["detail"] == f"Pulse not found with id: {pulse_id}"
 
 
-def test_add_pulse_attrs_on_pulse(client: TestClient, device_uuid: str) -> None:
+def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,

--- a/backend/tests/api/public/device/test_views.py
+++ b/backend/tests/api/public/device/test_views.py
@@ -97,19 +97,16 @@ def test_get_device_with_invalid_device_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid uuid"
-    assert data["detail"][0]["type"] == "type_error.uuid"
+    assert data["detail"][0]["msg"] == "value is not a valid integer"
+    assert data["detail"][0]["type"] == "type_error.integer"
 
 
 def test_get_device_with_nonexistent_device_id(client: TestClient) -> None:
-    response = client.get("/devices/00000000-0000-0000-0000-000000000000")
+    response = client.get("/devices/1000")
     data = response.json()
 
     assert response.status_code == 404
-    assert (
-        data["detail"]
-        == "Device not found with id: 00000000-0000-0000-0000-000000000000"
-    )
+    assert data["detail"] == "Device not found with id: 1000"
 
 
 def test_get_all_devices(client: TestClient) -> None:

--- a/backend/tests/api/public/pulse/test_views.py
+++ b/backend/tests/api/public/pulse/test_views.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 from fastapi.testclient import TestClient
 
 from api.utils.mock_data_generator import create_devices_and_pulses
@@ -93,7 +91,7 @@ def test_create_pulse_with_nonexistent_device_id(
     client: TestClient,
 ) -> None:
     pulse_payload = {
-        "device_id": str(uuid4()),
+        "device_id": 1000,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -128,8 +126,8 @@ def test_create_pulse_with_invalid_device_id(
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"][0]["msg"] == "value is not a valid uuid"
-    assert response.json()["detail"][0]["type"] == "type_error.uuid"
+    assert response.json()["detail"][0]["msg"] == "value is not a valid integer"
+    assert response.json()["detail"][0]["type"] == "type_error.integer"
 
 
 def test_create_pulse_with_invalid_creation_time(
@@ -185,12 +183,12 @@ def test_get_pulse_with_invalid_pulse_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid uuid"
-    assert data["detail"][0]["type"] == "type_error.uuid"
+    assert data["detail"][0]["msg"] == "value is not a valid integer"
+    assert data["detail"][0]["type"] == "type_error.integer"
 
 
 def test_get_pulse_with_nonexistent_pulse_id(client: TestClient) -> None:
-    pulse_id = uuid4()
+    pulse_id = 1000
     response = client.get(f"/pulses/{pulse_id}")
     data = response.json()
 

--- a/backend/tests/api/public/pulse/test_views.py
+++ b/backend/tests/api/public/pulse/test_views.py
@@ -3,9 +3,9 @@ from fastapi.testclient import TestClient
 from api.utils.mock_data_generator import create_devices_and_pulses
 
 
-def test_create_pulse(client: TestClient, device_uuid: str) -> None:
+def test_create_pulse(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -18,7 +18,7 @@ def test_create_pulse(client: TestClient, device_uuid: str) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert data["device_id"] == device_uuid
+    assert data["device_id"] == device_id
     assert data["delays"] == [1, 2, 3]
     assert data["signal"] == [1, 2, 3]
     assert data["integration_time"] == 100
@@ -26,9 +26,9 @@ def test_create_pulse(client: TestClient, device_uuid: str) -> None:
     assert data["pulse_id"] is not None
 
 
-def test_create_pulse_with_invalid_delays(client: TestClient, device_uuid: str) -> None:
+def test_create_pulse_with_invalid_delays(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, "a"],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -45,9 +45,9 @@ def test_create_pulse_with_invalid_delays(client: TestClient, device_uuid: str) 
     assert data["detail"][0]["type"] == "type_error.float"
 
 
-def test_create_pulse_with_invalid_signal(client: TestClient, device_uuid: str) -> None:
+def test_create_pulse_with_invalid_signal(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, "a"],
         "integration_time": 100,
@@ -66,10 +66,10 @@ def test_create_pulse_with_invalid_signal(client: TestClient, device_uuid: str) 
 
 def test_create_pulse_with_invalid_integration_time(
     client: TestClient,
-    device_uuid: str,
+    device_id: str,
 ) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": "a",
@@ -111,7 +111,7 @@ def test_create_pulse_with_nonexistent_device_id(
 
 def test_create_pulse_with_invalid_device_id(
     client: TestClient,
-    device_uuid: str,
+    device_id: str,
 ) -> None:
     pulse_payload = {
         "device_id": "a",
@@ -132,10 +132,10 @@ def test_create_pulse_with_invalid_device_id(
 
 def test_create_pulse_with_invalid_creation_time(
     client: TestClient,
-    device_uuid: str,
+    device_id: str,
 ) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -151,9 +151,9 @@ def test_create_pulse_with_invalid_creation_time(
     assert response.json()["detail"][0]["type"] == "value_error.datetime"
 
 
-def test_get_pulse(client: TestClient, device_uuid: str) -> None:
+def test_get_pulse(client: TestClient, device_id: str) -> None:
     pulse_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -170,7 +170,7 @@ def test_get_pulse(client: TestClient, device_uuid: str) -> None:
     data = response.json()
 
     assert response.status_code == 200
-    assert data["device_id"] == device_uuid
+    assert data["device_id"] == device_id
     assert data["delays"] == [1, 2, 3]
     assert data["signal"] == [1, 2, 3]
     assert data["integration_time"] == 100
@@ -196,9 +196,9 @@ def test_get_pulse_with_nonexistent_pulse_id(client: TestClient) -> None:
     assert data["detail"] == f"Pulse not found with id: {pulse_id}"
 
 
-def test_get_all_pulses(client: TestClient, device_uuid: str) -> None:
+def test_get_all_pulses(client: TestClient, device_id: str) -> None:
     pulse_1_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -211,7 +211,7 @@ def test_get_all_pulses(client: TestClient, device_uuid: str) -> None:
     pulse_1_data = pulse_1_response.json()
 
     pulse_2_payload = {
-        "device_id": device_uuid,
+        "device_id": device_id,
         "delays": [4, 5, 6],
         "signal": [4, 5, 6],
         "integration_time": 200,
@@ -228,13 +228,13 @@ def test_get_all_pulses(client: TestClient, device_uuid: str) -> None:
 
     assert response.status_code == 200
     assert len(data) == 2
-    assert data[0]["device_id"] == device_uuid
+    assert data[0]["device_id"] == device_id
     assert data[0]["delays"] == [1, 2, 3]
     assert data[0]["signal"] == [1, 2, 3]
     assert data[0]["integration_time"] == 100
     assert data[0]["creation_time"] == "2021-01-01T00:00:00"
     assert data[0]["pulse_id"] == pulse_1_data["pulse_id"]
-    assert data[1]["device_id"] == device_uuid
+    assert data[1]["device_id"] == device_id
     assert data[1]["delays"] == [4, 5, 6]
     assert data[1]["signal"] == [4, 5, 6]
     assert data[1]["integration_time"] == 200

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,7 +39,7 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
 
 
 @pytest.fixture()
-def device_uuid(client: TestClient) -> Generator[str, None, None]:
+def device_id(client: TestClient) -> Generator[str, None, None]:
     """Create a Device for testing purposes."""
     device_payload = {"friendly_name": "Glaze I"}
     response = client.post(


### PR DESCRIPTION
Trying to minimize the impact of https://github.com/GlazeTech/TeraStore/pull/64 I am splitting up the changes in different PRs.

**NOTE: to test this locally, you'll probably need to delete your current test Docker volume. DB operations will get weird if the index type has suddenly changed.**

This one changes db ids to be autoincrementing ints instead of UUIDs. This entails:

* Changing the model classes to use type `int | None = Field(default=None, primary_key=True)`. This means that the db will select an appropriate index value
* Fixing the type annotation in related classes
* Ensuring that functions that return a database model class return the `Read` version, which does not have an optional index
* Updating tests
* I spotted an error in `PulseKeyRegistry`: `key`, which is a string, was the primary key. This is a bad idea, we shall use a normal index instead

Closes #65 .