### PR TITLE
Clean up return types (and other small stuff)

### DIFF
--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -3,11 +3,7 @@ from pydantic.types import StrictStr
 from sqlmodel import Session, select
 
 from api.database import get_session
-from api.public.attrs.models import (
-    PulseAttrsStr,
-    PulseAttrsStrRead,
-    PulseKeyRegistry,
-)
+from api.public.attrs.models import PulseAttrsStr, PulseAttrsStrRead, PulseKeyRegistry
 from api.public.pulse.models import Pulse, PulseRead
 from api.utils.exceptions import PulseNotFoundError
 
@@ -89,14 +85,11 @@ def filter_on_key_value_pairs(
             return []
 
     for kv in kv_pairs:
-        key = kv.key
-        value = kv.value
-
         # Perform query for this key-value pair
         statement = (
             select(PulseAttrsStr.pulse_id)
-            .where(PulseAttrsStr.key == key)
-            .where(PulseAttrsStr.value == value)
+            .where(PulseAttrsStr.key == kv.key)
+            .where(PulseAttrsStr.value == kv.value)
         )
         pulse_ids = db.exec(statement).all()
         pulse_ids_list.append(set(pulse_ids))

--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -1,16 +1,24 @@
+from pydantic.types import StrictStr
 from sqlmodel import Field, SQLModel
 
 
-class PulseStrAttrs(SQLModel, table=True):
+class PulseAttrsBase(SQLModel):
+    key: str
+
+
+class PulseAttrsStr(PulseAttrsBase, table=True):
     """The purpose of this class is to interact with the database."""
 
     __tablename__ = "pulse_str_attrs"
 
-    key: str
-    value: str
+    value: StrictStr
     pulse_id: int = Field(foreign_key="pulses.pulse_id", index=True)
 
     index: int | None = Field(default=None, primary_key=True)
+
+
+class PulseAttrsStrRead(PulseAttrsBase):
+    value: StrictStr
 
 
 class PulseKeyRegistry(SQLModel, table=True):

--- a/backend/api/public/attrs/views.py
+++ b/backend/api/public/attrs/views.py
@@ -7,6 +7,7 @@ from api.public.attrs.crud import (
     read_all_keys,
     read_all_values_on_key,
 )
+from api.public.attrs.models import PulseAttrsStrRead
 
 router = APIRouter()
 
@@ -17,26 +18,16 @@ def get_all_keys(db: Session = Depends(get_session)) -> list[str]:
 
 
 @router.get("/{key}/values")
-def get_all_values_on_key(key: str, db: Session = Depends(get_session)) -> list[str]:
+def get_all_values_on_key(
+    key: str,
+    db: Session = Depends(get_session),
+) -> list[str]:
     return read_all_values_on_key(key=key, db=db)
 
 
 @router.post("/filter")
 def filter_attrs(
-    key_value_pairs: list[dict[str, str]],
+    kv_pairs: list[PulseAttrsStrRead],
     db: Session = Depends(get_session),
 ) -> list[int]:
-    """Filter pulses based on key-value pairs.
-
-    Example usage:
-    --------------
-        curl -X 'POST' \
-        'http://localhost:8000/attrs/filter' \
-        -H 'accept: application/json' \
-        -H 'Content-Type: application/json' \
-        -d '[
-        {"key": "angle", "value": "17"},
-        {"key": "substrate", "value": "plastic"}
-        ]'
-    """
-    return filter_on_key_value_pairs(key_value_pairs, db)
+    return filter_on_key_value_pairs(kv_pairs, db)

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -21,12 +21,14 @@ def read_devices(
     offset: int = 0,
     limit: int = 20,
     db: Session = Depends(get_session),
-) -> list[Device]:
-    return db.exec(select(Device).offset(offset).limit(limit)).all()
+) -> list[DeviceRead]:
+    statement = select(Device).offset(offset).limit(limit)
+    devices = db.exec(statement).all()
+    return [DeviceRead.from_orm(device) for device in devices]
 
 
-def read_device(device_id: int, db: Session = Depends(get_session)) -> Device:
+def read_device(device_id: int, db: Session = Depends(get_session)) -> DeviceRead:
     device = db.get(Device, device_id)
     if not device:
         raise DeviceNotFoundError(device_id=device_id)
-    return device
+    return DeviceRead.from_orm(device)

--- a/backend/api/public/device/views.py
+++ b/backend/api/public/device/views.py
@@ -3,12 +3,12 @@ from sqlmodel import Session
 
 from api.database import get_session
 from api.public.device.crud import create_device, read_device, read_devices
-from api.public.device.models import Device, DeviceCreate, DeviceRead
+from api.public.device.models import DeviceCreate, DeviceRead
 
 router = APIRouter()
 
 
-@router.post("", response_model=DeviceRead)
+@router.post("")
 def create_a_device(
     device: DeviceCreate,
     db: Session = Depends(get_session),
@@ -16,15 +16,15 @@ def create_a_device(
     return create_device(device=device, db=db)
 
 
-@router.get("", response_model=list[DeviceRead])
+@router.get("")
 def get_devices(
     offset: int = 0,
     limit: int = Query(default=100, lte=100),
     db: Session = Depends(get_session),
-) -> list[Device]:
+) -> list[DeviceRead]:
     return read_devices(offset=offset, limit=limit, db=db)
 
 
-@router.get("/{device_id}", response_model=DeviceRead)
-def get_device(device_id: int, db: Session = Depends(get_session)) -> Device:
+@router.get("/{device_id}")
+def get_device(device_id: int, db: Session = Depends(get_session)) -> DeviceRead:
     return read_device(device_id=device_id, db=db)

--- a/backend/api/public/pulse/models.py
+++ b/backend/api/public/pulse/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TCH003
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 from sqlalchemy.dialects import postgresql
 from sqlmodel import Column, Field, Float, SQLModel
@@ -12,9 +12,6 @@ from api.utils.helpers import (
     generate_scaled_numbers,
     get_now,
 )
-
-if TYPE_CHECKING:
-    from api.public.device.models import DeviceRead
 
 
 class PulseBase(SQLModel):
@@ -94,12 +91,6 @@ class PulseRead(PulseBase):
     pulse_id: int
 
 
-class PulseReadWithDevice(PulseRead):
-    """Model for reading a Pulse with its Device."""
-
-    device: DeviceRead
-
-
 class TemporaryPulseIdTable(SQLModel, table=True):
     """Temporary table for performing joins on pulse IDs.
 
@@ -111,4 +102,4 @@ class TemporaryPulseIdTable(SQLModel, table=True):
 
     __tablename__ = "temporary_pulse_id_table"
 
-    pulse_id: int = Field(default=None, primary_key=True)
+    pulse_id: int | None = Field(default=None, primary_key=True)

--- a/backend/api/public/pulse/views.py
+++ b/backend/api/public/pulse/views.py
@@ -5,18 +5,19 @@ from sqlmodel import Session
 
 from api.database import get_session
 from api.public.attrs.crud import add_str_attr, read_pulse_attrs
+from api.public.attrs.models import PulseAttrsStrRead
 from api.public.pulse.crud import (
     create_pulse,
     read_pulse,
     read_pulses,
     read_pulses_with_ids,
 )
-from api.public.pulse.models import Pulse, PulseCreate, PulseRead
+from api.public.pulse.models import PulseCreate, PulseRead
 
 router = APIRouter()
 
 
-@router.post("/create", response_model=PulseRead)
+@router.post("/create")
 def create_a_pulse(
     pulse: PulseCreate,
     db: Session = Depends(get_session),
@@ -32,35 +33,35 @@ def create_a_pulse(
         raise
 
 
-@router.get("", response_model=list[PulseRead])
+@router.get("")
 def get_pulses(
     offset: int = 0,
     limit: int = Query(default=100, lte=100),
     db: Session = Depends(get_session),
-) -> list[Pulse]:
+) -> list[PulseRead]:
     return read_pulses(offset=offset, limit=limit, db=db)
 
 
-@router.post("/get", response_model=list[PulseRead])
+@router.post("/get")
 def get_pulses_from_ids(
     ids: list[int],
     db: Session = Depends(get_session),
-) -> list[Pulse]:
+) -> list[PulseRead]:
     return read_pulses_with_ids(ids, db=db)
 
 
-@router.get("/{pulse_id}", response_model=PulseRead)
-def get_pulse(pulse_id: int, db: Session = Depends(get_session)) -> Pulse:
+@router.get("/{pulse_id}")
+def get_pulse(pulse_id: int, db: Session = Depends(get_session)) -> PulseRead:
     return read_pulse(pulse_id=pulse_id, db=db)
 
 
-@router.put("/{pulse_id}/attrs", response_model=PulseRead)
+@router.put("/{pulse_id}/attrs")
 def add_kv_str(
     pulse_id: int,
     key: str,
     value: str,
     db: Session = Depends(get_session),
-) -> Pulse:
+) -> PulseRead:
     return add_str_attr(key=key, value=value, pulse_id=pulse_id, db=db)
 
 
@@ -68,5 +69,5 @@ def add_kv_str(
 def get_pulse_keys(
     pulse_id: int,
     db: Session = Depends(get_session),
-) -> list[dict[str, str]]:
+) -> list[PulseAttrsStrRead]:
     return read_pulse_attrs(pulse_id=pulse_id, db=db)

--- a/backend/tests/api/public/attrs/test_views.py
+++ b/backend/tests/api/public/attrs/test_views.py
@@ -9,7 +9,8 @@ def test_get_all_keys(client: TestClient) -> None:
     response = client.get("/attrs/keys/")
 
     assert response.status_code == 200
-    assert response.json() == ["angle", "substrate"]
+    assert "angle" in response.json()
+    assert "substrate" in response.json()
 
 
 def test_get_all_values_on_key(client: TestClient) -> None:


### PR DESCRIPTION
**This PR should be looked at _after_ https://github.com/GlazeTech/TeraStore/pull/68 as it contains changes from that branch.**

This PR contains:

* More correct return types from the CRUDs and views; e.g. `PulseRead` instead of `Pulse`, because `Pulse` has an `Optional` `pulse_id`, while `PulseRead` does not
* Added Pydantic `StrictStr` type for `PulseAttrsStr` in the anticipation of new EAV data types. It is hoped that this will make it easier for us to return a correct type
* Renamed `PulseStrAttrs` to `PulseAttrsStr`
* Added a `PulseAttrsStrRead` class to return when you read all attrs on a pulse. This dispenses with the dictionary type. The class is also used as an input to the filter function
* Removed the use of the `execute()` function, as that is a SQLAlchemy function which returns `Any`'s. Changed to `exec()`, which is from SQLModel, that does return the correct type. This has led to a little further change in how I return an empty list in `filter_on_key_value_pairs()`
* Also got rid of the `and_` function, also from SQLAlchemy. Am instead chaining `where()`s in `filter_on_key_value_pairs()`
* Removed the `response_model` argument for FastAPI route decorators, as the return type should be plenty
* Removed `PulseReadWithDevice` because we don't use it
* Made `pulse_id` optional in `TemporaryPulseIdTable`, because it's supposed to be that
* Made a small change in `test_get_all_keys()`, because I can't be sure how a returned list is sorted