### PR TITLE
Add creation_time filter in backend.

### DIFF
--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+
+# Ruff wants this import to be in a TYPE_CHECKING block
+# THIS WILL BREAK PYDANTIC, DO NO DO IT
+from datetime import datetime  # noqa: TCH003
 from enum import Enum
 from typing import Self, TypeAlias
 
@@ -112,9 +116,16 @@ class PulseAttrsFloatFilter(PulseAttrsFilterBase):
     max_value: StrictFloat | StrictInt
 
 
+class PulseAttrsDatetimeFilter(PulseAttrsFilterBase):
+    min_value: datetime
+    max_value: datetime
+
+
 # Has to be defined after definition of both classes
 TAttrReadDataType: TypeAlias = PulseAttrsStrRead | PulseAttrsFloatRead
-TAttrFilterDataType: TypeAlias = PulseAttrsStrFilter | PulseAttrsFloatFilter
+TAttrFilterDataType: TypeAlias = (
+    PulseAttrsStrFilter | PulseAttrsFloatFilter | PulseAttrsDatetimeFilter
+)
 
 
 # Factory function for finding the correct PulseAttrs class


### PR DESCRIPTION
This PR adds the ability to filter on `creation_time` in the backend via the `/attrs/filter` route.

As `creation_time` is in the `pulses` table, there is a little piece of logic in `api/public/attrs/crud.py:filter_on_key_value_pairs` that checks if the instance is of a new class `PulseAttrsDatetimeFilter`. If so, a `SELECT` statement is performed on the `pulses` table with the given `min_value` and `max_value` as conditions. SQLModel/SQLAlchemy takes care of converting the `datetime` objects into something Postgres can digest (basically a well-formatted `timestamp` string such as `'2023-11-23T10:05:10.000000'`).

As mentioned, a `PulseAttrsDatetimeFilter` class is created, inheriting from `PulseAttrsFilterBase`. This has attributes `min_value` and `max_value`, which are `datetime`s. The type alias `TAttrFilterDataType` is extended to include this class.

The function `api/public/attrs/crud.py: create_attr_creation_time_filter_query` is responsible for forming the `SELECT` statement for `creation_time` filtering. Do note that this, in contrast to the other filter query creation functions, can in principle return a `SelectOfScalar[None]`, because `pulse_id` is optional on `Pulse`. The `select_statements` list type annotation is extended to accommodate this.

I have added test for a succesful `creation_time` filter query, for invalid `datetime` strings and for a query that returns nothing.

To filter via the API, call the route `/attrs/filter` with the following example JSON body:

```json
[
  {
    "key": "project",
    "value": "CGM"
  },
  {
    "key": "creation_time",
    "min_value": "2023-11-22T10:05:08",
    "max_value": "2023-11-23T10:05:10"
  }
]
```