### PR TITLE
Update to SQLModel 0.0.12.

### DIFF
--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -83,8 +83,10 @@ def read_pulse_attrs(
     for data_type in AttrDataType:
         attrs_class = get_pulse_attrs_class(data_type)
         attrs_read_class = get_pulse_attrs_read_class(data_type)
-        statement = select(attrs_class).where(attrs_class.pulse_id == pulse_id)
-        attrs = [attrs_read_class.from_orm(obj) for obj in db.exec(statement).all()]
+        results = db.exec(
+            select(attrs_class).where(attrs_class.pulse_id == pulse_id),
+        ).all()
+        attrs = [attrs_read_class.from_orm(obj) for obj in results]
         attrs_list += attrs
 
     return attrs_list
@@ -111,8 +113,9 @@ def read_all_values_on_key(
         raise AttrKeyDoesNotExistError(key=key)
 
     attrs_class = get_pulse_attrs_class(AttrDataType(existing_key.data_type))
-    statement = select(attrs_class.value).where(attrs_class.key == key).distinct()
-    return db.exec(statement).all()
+    return db.exec(
+        select(attrs_class.value).where(attrs_class.key == key).distinct(),
+    ).all()
 
 
 def filter_on_key_value_pairs(

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -22,8 +22,7 @@ def read_devices(
     limit: int = 20,
     db: Session = Depends(get_session),
 ) -> list[DeviceRead]:
-    statement = select(Device).offset(offset).limit(limit)
-    devices = db.exec(statement).all()
+    devices = db.exec(select(Device).offset(offset).limit(limit)).all()
     return [DeviceRead.from_orm(device) for device in devices]
 
 

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -21,8 +21,7 @@ def read_pulses(
     db: Session = Depends(get_session),
 ) -> list[PulseRead]:
     """Get all pulses in the database."""
-    statement = select(Pulse).offset(offset).limit(limit)
-    pulses = db.exec(statement).all()
+    pulses = db.exec(select(Pulse).offset(offset).limit(limit)).all()
     return [PulseRead.from_orm(pulse) for pulse in pulses]
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 
 dependencies = [
   "fastapi[all]==0.99.1",
-  "sqlmodel==0.0.8",
+  "sqlmodel==0.0.12",
   "psycopg2-binary==2.9.9",
 ]
 


### PR DESCRIPTION
This PR updates SQLModel dependency to 0.0.12.

I have had to put some `SELECT` statements directly into `db.exec()` methods, as the `SelectOfScalar` return type for these is `SelectOfScalar[<nothing>]`, which is kind of hard to work with.