### PR TITLE
Update to Python 3.12, SQLModel 0.0.12 and update dev dependencies

### DIFF
--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -83,8 +83,10 @@ def read_pulse_attrs(
     for data_type in AttrDataType:
         attrs_class = get_pulse_attrs_class(data_type)
         attrs_read_class = get_pulse_attrs_read_class(data_type)
-        statement = select(attrs_class).where(attrs_class.pulse_id == pulse_id)
-        attrs = [attrs_read_class.from_orm(obj) for obj in db.exec(statement).all()]
+        results = db.exec(
+            select(attrs_class).where(attrs_class.pulse_id == pulse_id),
+        ).all()
+        attrs = [attrs_read_class.from_orm(obj) for obj in results]
         attrs_list += attrs
 
     return attrs_list
@@ -111,8 +113,9 @@ def read_all_values_on_key(
         raise AttrKeyDoesNotExistError(key=key)
 
     attrs_class = get_pulse_attrs_class(AttrDataType(existing_key.data_type))
-    statement = select(attrs_class.value).where(attrs_class.key == key).distinct()
-    return db.exec(statement).all()
+    return db.exec(
+        select(attrs_class.value).where(attrs_class.key == key).distinct(),
+    ).all()
 
 
 def filter_on_key_value_pairs(

--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import Enum
 from typing import Self, TypeAlias
 
@@ -9,8 +10,10 @@ from sqlmodel import Field, SQLModel
 from api.utils.exceptions import AttrDataTypeDoesNotExistError
 
 # Must be defined early in file to avoid Pydantic panic
+# As soon as Mypy supports PEP 695, we should implement the new type syntax
+# See: https://github.com/python/mypy/issues/15238
 TAttrDataType: TypeAlias = StrictStr | StrictFloat
-TAttrDataTypeList: TypeAlias = list[StrictStr] | list[StrictFloat]
+TAttrDataTypeList: TypeAlias = Sequence[StrictStr] | Sequence[StrictFloat]
 
 
 class AttrDataType(str, Enum):

--- a/backend/api/public/attrs/views.py
+++ b/backend/api/public/attrs/views.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("/keys")
-def get_all_keys(db: Session = Depends(get_session)) -> list[str]:
+def get_all_keys(db: Session = Depends(get_session)) -> Sequence[str]:
     return read_all_keys(db=db)
 
 

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -22,8 +22,7 @@ def read_devices(
     limit: int = 20,
     db: Session = Depends(get_session),
 ) -> list[DeviceRead]:
-    statement = select(Device).offset(offset).limit(limit)
-    devices = db.exec(statement).all()
+    devices = db.exec(select(Device).offset(offset).limit(limit)).all()
     return [DeviceRead.from_orm(device) for device in devices]
 
 

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -37,7 +37,7 @@ def read_pulses_with_ids(
     pulses = db.exec(
         select(Pulse).join(
             TemporaryPulseIdTable,
-            TemporaryPulseIdTable.pulse_id == Pulse.pulse_id,
+            TemporaryPulseIdTable.pulse_id == Pulse.pulse_id,  # type: ignore[arg-type]
             isouter=False,
         ),
     ).all()

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -21,8 +21,7 @@ def read_pulses(
     db: Session = Depends(get_session),
 ) -> list[PulseRead]:
     """Get all pulses in the database."""
-    statement = select(Pulse).offset(offset).limit(limit)
-    pulses = db.exec(statement).all()
+    pulses = db.exec(select(Pulse).offset(offset).limit(limit)).all()
     return [PulseRead.from_orm(pulse) for pulse in pulses]
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
   { name = "Mads Ehrhorn", email = "mehkj@dtu.dk" },
   { name = "Bjørn Mølvig", email = "bhymo@dtu.dk" },
 ]
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.12,<3.13"
 readme = "README.md"
 dynamic = ["version"]
 
@@ -17,19 +17,19 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "mypy==1.5.1",
-  "black==23.9.1",
-  "ruff==0.0.292",
-  "pytest==7.4.2",
-  "types-psycopg2==2.9.21.14",
+  "mypy==1.7.0",
+  "black==23.11.0",
+  "ruff==0.1.6",
+  "pytest==7.4.3",
+  "types-psycopg2==2.9.21.16",
   "pytest-cov==4.1.0",
 ]
 dev = [
-  "mypy==1.5.1",
-  "black==23.9.1",
-  "ruff==0.0.292",
-  "pytest==7.4.2",
-  "types-psycopg2==2.9.21.14",
+  "mypy==1.7.0",
+  "black==23.11.0",
+  "ruff==0.1.6",
+  "pytest==7.4.3",
+  "types-psycopg2==2.9.21.16",
   "pytest-cov==4.1.0",
 ]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 
 dependencies = [
   "fastapi[all]==0.99.1",
-  "sqlmodel==0.0.8",
+  "sqlmodel==0.0.12",
   "psycopg2-binary==2.9.9",
 ]
 

--- a/docker/Dockerfile.backend.dev
+++ b/docker/Dockerfile.backend.dev
@@ -1,5 +1,5 @@
 # Use the same base image as production Dockerfile to ensure consistency.
-FROM python:3.11
+FROM python:3.12
 
 WORKDIR /app
 

--- a/docker/Dockerfile.backend.prod
+++ b/docker/Dockerfile.backend.prod
@@ -1,11 +1,11 @@
 # Strongly inspired by https://fastapi.tiangolo.com/deployment/docker/#build-a-docker-image-for-fastapi
 # Requirements stage to avoid having unnecesary files in final image
-FROM python:3.11 as requirements-stage
+FROM python:3.12 as requirements-stage
 WORKDIR /tmp
 COPY ./pyproject.toml /tmp/
 
 # Create webserver image
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.12
 WORKDIR /app
 COPY --from=requirements-stage /tmp/pyproject.toml /app/pyproject.toml
 RUN pip install --no-cache-dir --upgrade .

--- a/docker/Dockerfile.backend.prod
+++ b/docker/Dockerfile.backend.prod
@@ -5,7 +5,7 @@ WORKDIR /tmp
 COPY ./pyproject.toml /tmp/
 
 # Create webserver image
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.12
+FROM python:3.12
 WORKDIR /app
 COPY --from=requirements-stage /tmp/pyproject.toml /app/pyproject.toml
 RUN pip install --no-cache-dir --upgrade .

--- a/docker/Dockerfile.backend.test
+++ b/docker/Dockerfile.backend.test
@@ -1,5 +1,5 @@
 # Use the same base image as production Dockerfile to ensure consistency.
-FROM python:3.11
+FROM python:3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
**🚨🚨THIS IS MINOR OPEN HEART SURGERY. IT IS A-OK IF THE REVIEWER IS UNSURE WHETHER THIS IS A GOOD IDEA OR NOT. PLEASE KEEP AN OPEN MIND.🚨🚨**

This PR updates to Python 3.12 and SQLModel 0.0.12.

Additionally, the following dev dependencies are updated:

* Mypy
* Black
* Ruff
* Pytest
* types-psycopg2

It is my opinion that a healthy project updates often (tho not too often), hence this PR.

The following code has been updated to reflect changes in packages:

* All `db.query()` calls have been replaced with `db.exec()`, as `db.query()` has begun deprecation warnings.

* Where I had mixed `Sequence` and `list`, Mypy rightfully complained. `Sequence` is now used where appropriate.

* On line 139 in `api/public/attrs/crud.py` I have exchanged `filter` for `where`. `filter` is a synonym for SQLAlchemy's `where`, while `where` in this case is SQLModel's `where`... which is the one we want to use. This was uncovered only by upgrading the dependencies.

* Line 155 in `api/public/attrs/crud.py` now accesses a `tuple` instead of a `dict`, as that is what SQLAlchemy 2's `execute` returns: a `Sequence[Row[Any]]` where `Row` is a `tuple`. This doesn't hurt, as we only `SELECT` `pulse_id`, so we are not in danger of accessing the wrong index.

* Line 40 in `api/public/pulse/crud.py` requires some defending: I ignore the Mypy linting, because I get an error I cannot explain nor find the reason for (see below). The code runs fine. Any help appreciated.
```
Argument 2 to "join" of "Select" has incompatible type "bool"; expected "ColumnElement[Any] | _HasClauseElement | SQLCoreOperations[Any] | ExpressionElementRole[Any] | Callable[[], ColumnElement[Any]] | LambdaElement | OnClauseRole | None"  [arg-type]mypy
```

* I've packed some of the `select` statements directly inside a `db.exec()`, as otherwise the returned type would be `SelectOfScalar[<nothing>]`, which is hard to work with.

* I have also removed the dependency on the `tiangolo/uvicorn-gunicorn-fastapi` image in `Dockerfile.backend.prod`, because he doesn't offer a Python 3.12 version. In any case, he himself writes that you probably don't need this image (even though I will grant that it is unclear whether he means only for Kubernetes?) (see screenshot below) I will say, tho, that a section title with red alarms and "YOU PROBABLY DON'T NEED THIS IMAGE" is probably trying to convey that no one needs it.

![CleanShot 2023-11-22 at 13 48 23@2x](https://github.com/GlazeTech/TeraStore/assets/15174457/7ddf10e8-e89c-4d1e-b33f-ca3c6dc857bd)