### PR TITLE
Updated table model IDs to UUID.

### DIFF
--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from datetime import datetime  # noqa: TCH003
 from enum import Enum
 from typing import Self, TypeAlias
+from uuid import UUID, uuid4
 
 from pydantic.types import StrictFloat, StrictInt, StrictStr
 from sqlmodel import Field, SQLModel
@@ -51,9 +52,9 @@ class PulseAttrsStr(PulseAttrsBase, table=True):
     __tablename__ = "pulse_str_attrs"
 
     value: StrictStr
-    pulse_id: int = Field(foreign_key="pulses.pulse_id", index=True)
+    pulse_id: UUID = Field(foreign_key="pulses.pulse_id", index=True)
 
-    index: int | None = Field(default=None, primary_key=True)
+    index: UUID = Field(default_factory=uuid4, primary_key=True)
 
 
 class PulseAttrsStrRead(PulseAttrsReadBase):
@@ -86,9 +87,9 @@ class PulseAttrsFloat(PulseAttrsBase, table=True):
     __tablename__ = "pulse_float_attrs"
 
     value: StrictFloat
-    pulse_id: int = Field(foreign_key="pulses.pulse_id", index=True)
+    pulse_id: UUID = Field(foreign_key="pulses.pulse_id", index=True)
 
-    index: int | None = Field(default=None, primary_key=True)
+    index: UUID = Field(default_factory=uuid4, primary_key=True)
 
 
 class PulseAttrsFloatRead(PulseAttrsReadBase):
@@ -158,4 +159,4 @@ class PulseKeyRegistry(SQLModel, table=True):
     key: str
     data_type: str
 
-    index: int | None = Field(default=None, primary_key=True)
+    index: UUID = Field(default_factory=uuid4, primary_key=True)

--- a/backend/api/public/attrs/views.py
+++ b/backend/api/public/attrs/views.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
@@ -34,5 +35,5 @@ def get_all_values_on_key(
 def filter_attrs(
     kv_pairs: Sequence[TAttrFilterDataType],
     db: Session = Depends(get_session),
-) -> list[int]:
+) -> list[UUID]:
     return filter_on_key_value_pairs(kv_pairs, db)

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import Depends
 from sqlmodel import Session, select
 
@@ -26,7 +28,7 @@ def read_devices(
     return [DeviceRead.from_orm(device) for device in devices]
 
 
-def read_device(device_id: int, db: Session = Depends(get_session)) -> DeviceRead:
+def read_device(device_id: UUID, db: Session = Depends(get_session)) -> DeviceRead:
     device = db.get(Device, device_id)
     if not device:
         raise DeviceNotFoundError(device_id=device_id)

--- a/backend/api/public/device/models.py
+++ b/backend/api/public/device/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Self
+from uuid import UUID, uuid4
 
 from sqlmodel import Field, SQLModel
 
@@ -24,7 +25,7 @@ class Device(DeviceBase, table=True):
 
     __tablename__ = "devices"
 
-    device_id: int | None = Field(default=None, primary_key=True)
+    device_id: UUID = Field(default_factory=uuid4, primary_key=True)
 
 
 class DeviceCreate(DeviceBase):
@@ -52,4 +53,4 @@ class DeviceRead(DeviceBase):
     from the db, as this requires the device_id.
     """
 
-    device_id: int
+    device_id: UUID

--- a/backend/api/public/device/views.py
+++ b/backend/api/public/device/views.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
@@ -26,5 +28,5 @@ def get_devices(
 
 
 @router.get("/{device_id}")
-def get_device(device_id: int, db: Session = Depends(get_session)) -> DeviceRead:
+def get_device(device_id: UUID, db: Session = Depends(get_session)) -> DeviceRead:
     return read_device(device_id=device_id, db=db)

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import Depends
 from sqlmodel import Session, select
 
@@ -26,7 +28,7 @@ def read_pulses(
 
 
 def read_pulses_with_ids(
-    ids: list[int],
+    ids: list[UUID],
     db: Session = Depends(get_session),
 ) -> list[PulseRead]:
     # Save wanted ID's in a temporary table
@@ -48,7 +50,7 @@ def read_pulses_with_ids(
     return [PulseRead.from_orm(pulse) for pulse in pulses]
 
 
-def read_pulse(pulse_id: int, db: Session = Depends(get_session)) -> PulseRead:
+def read_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> PulseRead:
     pulse = db.get(Pulse, pulse_id)
     if not pulse:
         raise PulseNotFoundError(pulse_id=pulse_id)

--- a/backend/api/public/pulse/models.py
+++ b/backend/api/public/pulse/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TCH003
 from typing import Self
+from uuid import UUID, uuid4
 
 from sqlalchemy.dialects import postgresql
 from sqlmodel import Column, Field, Float, SQLModel
@@ -34,7 +35,7 @@ class PulseBase(SQLModel):
     signal: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
     integration_time: int
     creation_time: datetime
-    device_id: int = Field(foreign_key="devices.device_id")
+    device_id: UUID = Field(foreign_key="devices.device_id")
 
 
 class Pulse(PulseBase, table=True):
@@ -45,7 +46,7 @@ class Pulse(PulseBase, table=True):
 
     __tablename__ = "pulses"
 
-    pulse_id: int | None = Field(default=None, primary_key=True)
+    pulse_id: UUID = Field(default_factory=uuid4, primary_key=True)
 
 
 class PulseCreate(PulseBase):
@@ -58,7 +59,7 @@ class PulseCreate(PulseBase):
     @classmethod
     def create_mock(
         cls: type[PulseCreate],
-        device_id: int,
+        device_id: UUID,
         length: int = 600,
         timescale: float = 1e-10,
         amplitude: float = 100.0,
@@ -88,7 +89,7 @@ class PulseRead(PulseBase):
     from the db, as this requires the pulse_id.
     """
 
-    pulse_id: int
+    pulse_id: UUID
 
 
 class TemporaryPulseIdTable(SQLModel, table=True):
@@ -102,4 +103,4 @@ class TemporaryPulseIdTable(SQLModel, table=True):
 
     __tablename__ = "temporary_pulse_id_table"
 
-    pulse_id: int | None = Field(default=None, primary_key=True)
+    pulse_id: UUID = Field(default_factory=uuid4, primary_key=True)

--- a/backend/api/public/pulse/views.py
+++ b/backend/api/public/pulse/views.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from psycopg2.errors import ForeignKeyViolation
 from sqlalchemy.exc import DBAPIError
@@ -47,20 +49,20 @@ def get_pulses(
 
 @router.post("/get")
 def get_pulses_from_ids(
-    ids: list[int],
+    ids: list[UUID],
     db: Session = Depends(get_session),
 ) -> list[PulseRead]:
     return read_pulses_with_ids(ids, db=db)
 
 
 @router.get("/{pulse_id}")
-def get_pulse(pulse_id: int, db: Session = Depends(get_session)) -> PulseRead:
+def get_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> PulseRead:
     return read_pulse(pulse_id=pulse_id, db=db)
 
 
 @router.put("/{pulse_id}/attrs")
 def add_kv_pair(
-    pulse_id: int,
+    pulse_id: UUID,
     kv_pair: PulseAttrsCreateBase,
     db: Session = Depends(get_session),
 ) -> PulseRead:
@@ -69,7 +71,7 @@ def add_kv_pair(
 
 @router.get("/{pulse_id}/attrs")
 def get_pulse_keys(
-    pulse_id: int,
+    pulse_id: UUID,
     db: Session = Depends(get_session),
 ) -> list[TAttrReadDataType]:
     return read_pulse_attrs(pulse_id=pulse_id, db=db)

--- a/backend/api/utils/exceptions.py
+++ b/backend/api/utils/exceptions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
+
+if TYPE_CHECKING:
+    from uuid import UUID
 
 
 class PulseNotFoundError(Exception):
     """Exception raised when the data type of an attribute is not supported."""
 
-    def __init__(self: Self, pulse_id: int) -> None:
+    def __init__(self: Self, pulse_id: UUID) -> None:
         self.pulse_id = pulse_id
         super().__init__(f"Pulse not found with id: {pulse_id}")
 
@@ -14,7 +17,7 @@ class PulseNotFoundError(Exception):
 class DeviceNotFoundError(Exception):
     """Exception raised when the data type of an attribute is not supported."""
 
-    def __init__(self: Self, device_id: int) -> None:
+    def __init__(self: Self, device_id: UUID) -> None:
         self.device_id = device_id
         super().__init__(f"Device not found with id: {device_id}")
 

--- a/backend/tests/api/public/attrs/test_views.py
+++ b/backend/tests/api/public/attrs/test_views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
 
@@ -42,7 +43,7 @@ def test_get_all_values_on_non_existing_key(client: TestClient) -> None:
     assert response_data["detail"] == "Key non-existing-key does not exist."
 
 
-def test_get_attrs_on_pulse(client: TestClient, device_id: int) -> None:
+def test_get_attrs_on_pulse(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -85,7 +86,7 @@ def test_get_attrs_on_pulse(client: TestClient, device_id: int) -> None:
 
 
 def test_get_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
-    pulse_id = 1000
+    pulse_id = uuid4()
 
     response = client.get(f"/pulses/{pulse_id}/attrs/")
 
@@ -95,7 +96,7 @@ def test_get_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
     assert response_data["detail"] == f"Pulse not found with id: {pulse_id}"
 
 
-def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: int) -> None:
+def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -128,7 +129,7 @@ def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: int) -> None:
 
 
 def test_add_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
-    pulse_id = 1000
+    pulse_id = uuid4()
 
     attrs_payload = PulseAttrsStrCreate.create_mock().as_dict()
 
@@ -143,7 +144,7 @@ def test_add_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
     assert response_data["detail"] == f"Pulse not found with id: {pulse_id}"
 
 
-def test_add_existing_attr_wrong_type(client: TestClient, device_id: int) -> None:
+def test_add_existing_attr_wrong_type(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -179,7 +180,7 @@ def test_add_existing_attr_wrong_type(client: TestClient, device_id: int) -> Non
     )
 
 
-def test_filtering_pulses_float(client: TestClient, device_id: int) -> None:
+def test_filtering_pulses_float(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -217,7 +218,7 @@ def test_filtering_pulses_float(client: TestClient, device_id: int) -> None:
 
 def test_filtering_pulses_string(
     client: TestClient,
-    device_id: int,
+    device_id: UUID,
 ) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
@@ -253,7 +254,7 @@ def test_filtering_pulses_string(
     assert pulse_id in response_data
 
 
-def test_filter_all_datatypes(client: TestClient, device_id: int) -> None:
+def test_filter_all_datatypes(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -302,7 +303,7 @@ def test_filter_all_datatypes(client: TestClient, device_id: int) -> None:
     assert pulse_id in response_data
 
 
-def test_filter_no_kv_given(client: TestClient, device_id: str) -> None:
+def test_filter_no_kv_given(client: TestClient) -> None:
     response = client.post("/attrs/filter/", json=[])
 
     response_data = response.json()
@@ -311,7 +312,7 @@ def test_filter_no_kv_given(client: TestClient, device_id: str) -> None:
     assert response_data == []
 
 
-def test_filter_no_kv_one_pulse(client: TestClient, device_id: int) -> None:
+def test_filter_no_kv_one_pulse(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -329,7 +330,7 @@ def test_filter_no_kv_one_pulse(client: TestClient, device_id: int) -> None:
     assert response_data == [pulse_id]
 
 
-def test_filter_non_existent_key(client: TestClient, device_id: str) -> None:
+def test_filter_non_existent_key(client: TestClient) -> None:
     filtering_json = [
         {
             "key": "non-existent-key",
@@ -345,7 +346,7 @@ def test_filter_non_existent_key(client: TestClient, device_id: str) -> None:
     assert response_data["detail"] == "Key non-existent-key does not exist."
 
 
-def test_filter_one_wrong(client: TestClient, device_id: int) -> None:
+def test_filter_one_wrong(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
 
     pulse_response = client.post(
@@ -394,7 +395,7 @@ def test_filter_one_wrong(client: TestClient, device_id: int) -> None:
     assert len(response_data) == 0
 
 
-def test_filter_valid_creation_time(client: TestClient, device_id: int) -> None:
+def test_filter_valid_creation_time(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
     pulse_response = client.post(
         "/pulses/create/",
@@ -424,7 +425,7 @@ def test_filter_valid_creation_time(client: TestClient, device_id: int) -> None:
     assert pulse_id in response_data
 
 
-def test_filter_invalid_creation_time(client: TestClient, device_id: int) -> None:
+def test_filter_invalid_creation_time(client: TestClient, device_id: UUID) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
     pulse_response = client.post(
         "/pulses/create/",
@@ -445,7 +446,10 @@ def test_filter_invalid_creation_time(client: TestClient, device_id: int) -> Non
     assert response.status_code == 422
 
 
-def test_filter_valid_creation_time_no_hits(client: TestClient, device_id: int) -> None:
+def test_filter_valid_creation_time_no_hits(
+    client: TestClient,
+    device_id: UUID,
+) -> None:
     pulse_payload = PulseCreate.create_mock(device_id=device_id).as_dict()
     pulse_response = client.post(
         "/pulses/create/",

--- a/backend/tests/api/public/device/test_views.py
+++ b/backend/tests/api/public/device/test_views.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from fastapi.testclient import TestClient
 
 from api.public.device.models import DeviceCreate
@@ -97,16 +99,17 @@ def test_get_device_with_invalid_device_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid integer"
-    assert data["detail"][0]["type"] == "type_error.integer"
+    assert data["detail"][0]["msg"] == "value is not a valid uuid"
+    assert data["detail"][0]["type"] == "type_error.uuid"
 
 
 def test_get_device_with_nonexistent_device_id(client: TestClient) -> None:
-    response = client.get("/devices/1000")
+    device_id = uuid4()
+    response = client.get(f"/devices/{device_id}")
     data = response.json()
 
     assert response.status_code == 404
-    assert data["detail"] == "Device not found with id: 1000"
+    assert data["detail"] == f"Device not found with id: {device_id}"
 
 
 def test_get_all_devices(client: TestClient) -> None:

--- a/backend/tests/api/public/pulse/test_views.py
+++ b/backend/tests/api/public/pulse/test_views.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from fastapi.testclient import TestClient
 
 from api.utils.mock_data_generator import create_devices_and_pulses
@@ -91,7 +93,7 @@ def test_create_pulse_with_nonexistent_device_id(
     client: TestClient,
 ) -> None:
     pulse_payload = {
-        "device_id": 1000,
+        "device_id": str(uuid4()),
         "delays": [1, 2, 3],
         "signal": [1, 2, 3],
         "integration_time": 100,
@@ -126,8 +128,8 @@ def test_create_pulse_with_invalid_device_id(
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"][0]["msg"] == "value is not a valid integer"
-    assert response.json()["detail"][0]["type"] == "type_error.integer"
+    assert response.json()["detail"][0]["msg"] == "value is not a valid uuid"
+    assert response.json()["detail"][0]["type"] == "type_error.uuid"
 
 
 def test_create_pulse_with_invalid_creation_time(
@@ -183,12 +185,12 @@ def test_get_pulse_with_invalid_pulse_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid integer"
-    assert data["detail"][0]["type"] == "type_error.integer"
+    assert data["detail"][0]["msg"] == "value is not a valid uuid"
+    assert data["detail"][0]["type"] == "type_error.uuid"
 
 
 def test_get_pulse_with_nonexistent_pulse_id(client: TestClient) -> None:
-    pulse_id = 1000
+    pulse_id = uuid4()
     response = client.get(f"/pulses/{pulse_id}")
     data = response.json()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
@@ -39,7 +40,7 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
 
 
 @pytest.fixture()
-def device_id(client: TestClient) -> Generator[int, None, None]:
+def device_id(client: TestClient) -> Generator[UUID, None, None]:
     """Create a Device for testing purposes."""
     device_payload = {"friendly_name": "Glaze I"}
     response = client.post(


### PR DESCRIPTION
This closes issue #91 . The below is copy-pasted from that issue:

> SQLModels data model where SERIAL IDs are created by SQLAlchemy, leaving a SQLModel table model to have an Optional ID, gives problems.
> 
> Specifically, on bulk inserts, we need to refresh every pulse, which SQLModel does via single transactions. We can use SQLAlchemy for this, but that gives us type problems because the table model must have Column types to be recognized by Mypy as valid for the needed SQLAlchemy operations insert and returning.
> 
> I thus propose we switch back to using UUIDs for db IDs, and let the Python client generated them. This also does away with the Optional IDs in all table models.
> 
> There is a chance of hash collisions, but I think we can neglect that: https://math.stackexchange.com/questions/4697032/threshold-for-the-number-of-uuids-generated-per-millisecond-at-which-the-colli

This PR simply changes all table model IDs to UUIDs, and adjusts the dependent functions.