### PR TITLE
Upload pulses

### DIFF
--- a/backend/api/public/pulse/models.py
+++ b/backend/api/public/pulse/models.py
@@ -19,7 +19,7 @@ from api.utils.helpers import (
 class TPulseDict(TypedDict):
     delays: list[float]
     signal: list[float]
-    integration_time: int
+    integration_time_ms: int
     creation_time: str
     device_id: str
     pulse_attributes: list[AttrDict]
@@ -43,7 +43,7 @@ class PulseBase(SQLModel):
 
     delays: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
     signal: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
-    integration_time: int
+    integration_time_ms: int
     creation_time: datetime
     device_id: UUID = Field(foreign_key="devices.device_id")
 
@@ -65,7 +65,7 @@ class Pulse(PulseBase, table=True):
         return Pulse(
             delays=pulse["delays"],
             signal=pulse["signal"],
-            integration_time=pulse["integration_time"],
+            integration_time_ms=pulse["integration_time_ms"],
             creation_time=pulse["creation_time"],
             device_id=pulse["device_id"],
         )
@@ -91,7 +91,7 @@ class PulseCreate(PulseBase):
         return cls(
             delays=generate_scaled_numbers(length, timescale),
             signal=generate_random_numbers(length, -amplitude, amplitude),
-            integration_time=generate_random_integration_time(),
+            integration_time_ms=generate_random_integration_time(),
             creation_time=get_now(),
             device_id=device_id,
             pulse_attributes=[],
@@ -104,7 +104,7 @@ class PulseCreate(PulseBase):
         return {
             "delays": self.delays,
             "signal": self.signal,
-            "integration_time": self.integration_time,
+            "integration_time_ms": self.integration_time_ms,
             "creation_time": self.creation_time.isoformat(),
             "device_id": str(self.device_id),
             "pulse_attributes": pulse_attributes,

--- a/backend/api/utils/helpers.py
+++ b/backend/api/utils/helpers.py
@@ -40,7 +40,7 @@ def create_mock_pulse(
     return {
         "delays": generate_scaled_numbers(length, timescale),
         "signal": generate_random_numbers(length, -amplitude, amplitude),
-        "integration_time": generate_random_integration_time(),
+        "integration_time_ms": generate_random_integration_time(),
         "creation_time": get_now(),
         "device_id": device_id,
     }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -10,6 +10,7 @@ import {
 	PulseID,
 } from "interfaces";
 import { BackendTHzDevice } from "interfaces/backend";
+import { ap } from "vitest/dist/reporters-5f784f42.js";
 
 const api = setupCache(
 	axios.create({
@@ -88,17 +89,13 @@ export async function getPulses(pulseIDs: PulseID[]): Promise<Pulse[]> {
 	);
 }
 
-// TODO: Implement uploadPulses
-// export async function uploadPulses(pulses: AnnotatedPulse[]) {
-// 	return api.post<boolean>("/pulses/upload", pulses).then((resp) => resp.data);
-// }
-
-export async function uploadPulses(_: AnnotatedPulse[]) {
-	return new Promise<void>((resolve) => {
-		setTimeout(() => {
-			resolve();
-		}, 1000);
-	});
+export async function uploadPulses(pulses: AnnotatedPulse[]) {
+	return api
+		.post<PulseID[]>("/pulses/create", pulses)
+		.then((resp) => resp.data)
+		.catch((err) => {
+			console.log(err);
+		});
 }
 
 export async function getDevices() {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -10,7 +10,6 @@ import {
 	PulseID,
 } from "interfaces";
 import { BackendTHzDevice } from "interfaces/backend";
-import { ap } from "vitest/dist/reporters-5f784f42.js";
 
 const api = setupCache(
 	axios.create({
@@ -91,7 +90,10 @@ export async function getPulses(pulseIDs: PulseID[]): Promise<Pulse[]> {
 
 export async function uploadPulses(pulses: AnnotatedPulse[]) {
 	return api
-		.post<PulseID[]>("/pulses/create", pulses)
+		.post<PulseID[]>(
+			"/pulses/create",
+			pulses.map((pulse) => pulse.asBackendCompatible()),
+		)
 		.then((resp) => resp.data)
 		.catch((err) => {
 			console.log(err);

--- a/frontend/src/classes/Pulse.ts
+++ b/frontend/src/classes/Pulse.ts
@@ -63,6 +63,28 @@ export class AnnotatedPulse {
 			parsed.pulse_attributes,
 		);
 	}
+
+	static pulseAttrAsBackendCompatible(key: string, value: string | number) {
+		const dataType = typeof value === "string" ? "string" : "float";
+		return {
+			key: key,
+			value: value,
+			data_type: dataType,
+		};
+	}
+
+	asBackendCompatible() {
+		return {
+			delays: this.pulse.time,
+			signal: this.pulse.signal,
+			integration_time_ms: this.integration_time_ms,
+			creation_time: this.creation_time.toISOString(),
+			device_id: this.device_id,
+			pulse_attributes: this.pulse_attributes.map((attr) =>
+				AnnotatedPulse.pulseAttrAsBackendCompatible(attr.key, attr.value),
+			),
+		};
+	}
 }
 
 const annotatedPulseSchema = z.object({

--- a/frontend/tests/api/index.test.ts
+++ b/frontend/tests/api/index.test.ts
@@ -1,4 +1,6 @@
+import { readTestingAsset } from "@tests/testing-utils";
 import { getFilteredPulses, getPulseKeys } from "api";
+import { uploadPulses } from "api";
 import {
 	DateAttrKey,
 	FilterResult,
@@ -6,12 +8,10 @@ import {
 	PulseNumberFilter,
 	PulseStringFilter,
 } from "classes";
-import { KVType, PulseFilter } from "interfaces";
-import { describe, expect, test } from "vitest";
-import { uploadPulses } from "api";
 import { extractPulses } from "helpers/data-io";
+import { KVType, PulseFilter } from "interfaces";
 import { BackendTHzDevice } from "interfaces";
-import { readTestingAsset } from "@tests/testing-utils";
+import { describe, expect, test } from "vitest";
 
 describe("getFilteredPulses", async () => {
 	const pulseKeys = await getPulseKeys();
@@ -68,14 +68,26 @@ describe("uploadPulses", () => {
 			device_id: "5042dbda-e9bc-4216-a614-ac56d0a32023",
 		},
 	];
-	const pulses = extractPulses(
-		readTestingAsset("valid-annotated-pulse.json"),
-		devices,
-	);
 
-	test("should upload pulses successfully", async () => {
+	test("should upload single pulse successfully", async () => {
+		const pulses = extractPulses(
+			readTestingAsset("valid-annotated-pulse.json"),
+			devices,
+		);
 		const result = await uploadPulses(pulses);
-		console.log(result);
+		expect(Array.isArray(result)).toBe(true);
+		if (result) {
+			expect(result.length).toBe(pulses.length);
+			expect(typeof result[0]).toBe("string");
+		}
+	});
+
+	test("should upload multiple pulses successfully", async () => {
+		const pulses = extractPulses(
+			readTestingAsset("valid-annotated-pulse-list.json"),
+			devices,
+		);
+		const result = await uploadPulses(pulses);
 		expect(Array.isArray(result)).toBe(true);
 		if (result) {
 			expect(result.length).toBe(pulses.length);

--- a/frontend/tests/api/index.test.ts
+++ b/frontend/tests/api/index.test.ts
@@ -8,6 +8,10 @@ import {
 } from "classes";
 import { KVType, PulseFilter } from "interfaces";
 import { describe, expect, test } from "vitest";
+import { uploadPulses } from "api";
+import { extractPulses } from "helpers/data-io";
+import { BackendTHzDevice } from "interfaces";
+import { readTestingAsset } from "@tests/testing-utils";
 
 describe("getFilteredPulses", async () => {
 	const pulseKeys = await getPulseKeys();
@@ -54,5 +58,28 @@ describe("getFilteredPulses", async () => {
 		const result = await getFilteredPulses(filters);
 		expect(result).toBeInstanceOf(FilterResult);
 		expect(result.nPulses).toBeGreaterThan(0);
+	});
+});
+
+describe("uploadPulses", () => {
+	const devices: BackendTHzDevice[] = [
+		{
+			friendly_name: "My friendly device",
+			device_id: "5042dbda-e9bc-4216-a614-ac56d0a32023",
+		},
+	];
+	const pulses = extractPulses(
+		readTestingAsset("valid-annotated-pulse.json"),
+		devices,
+	);
+
+	test("should upload pulses successfully", async () => {
+		const result = await uploadPulses(pulses);
+		console.log(result);
+		expect(Array.isArray(result)).toBe(true);
+		if (result) {
+			expect(result.length).toBe(pulses.length);
+			expect(typeof result[0]).toBe("string");
+		}
 	});
 });

--- a/frontend/tests/helpers/data-io.test.ts
+++ b/frontend/tests/helpers/data-io.test.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import {
 	AnnotatedPulse,
 	AnnotatedPulseParsingError,
@@ -9,6 +7,7 @@ import {
 import { extractPulses, formatFileSize } from "helpers/data-io";
 import { BackendTHzDevice } from "interfaces";
 import { describe, expect, test } from "vitest";
+import { readTestingAsset } from "@tests/testing-utils";
 
 describe("extractPulses", () => {
 	const devices: BackendTHzDevice[] = [
@@ -22,19 +21,15 @@ describe("extractPulses", () => {
 		},
 	];
 
-	const root = path.resolve(__dirname, "../../");
-	const readFile = (name: string) =>
-		fs.readFileSync(path.join(root, "tests", "testing-assets", name), "utf-8");
-
 	test("should extract single pulse from file content succesfully", () => {
-		const fileContent = readFile("valid-annotated-pulse.json");
+		const fileContent = readTestingAsset("valid-annotated-pulse.json");
 		const result = extractPulses(fileContent, devices);
 		expect(result.every((item) => item instanceof AnnotatedPulse)).toBe(true);
 		expect(result.length).toBe(1);
 	});
 
 	test("should extract pulses from array in file content succesfully", () => {
-		const fileContent = readFile("valid-annotated-pulse-list.json");
+		const fileContent = readTestingAsset("valid-annotated-pulse-list.json");
 		const result = extractPulses(fileContent, devices);
 		expect(result.every((item) => item instanceof AnnotatedPulse)).toBe(true);
 		expect(result.length).toBe(2);
@@ -56,19 +51,25 @@ describe("extractPulses", () => {
 
 	test("should throw error if date format is wrong", () => {
 		expect(() => {
-			extractPulses(readFile("annotated-pulse-wrong-date.json"), devices);
+			extractPulses(
+				readTestingAsset("annotated-pulse-wrong-date.json"),
+				devices,
+			);
 		}).toThrowError(InvalidCreationTimeError);
 	});
 
 	test("should throw error if device ID does not exist", () => {
 		expect(() => {
-			extractPulses(readFile("annotated-pulse-wrong-device-id.json"), devices);
+			extractPulses(
+				readTestingAsset("annotated-pulse-wrong-device-id.json"),
+				devices,
+			);
 		}).toThrowError(InvalidDeviceIDError);
 	});
 
 	test("should throw error if file is missing attributes", () => {
 		expect(() => {
-			extractPulses(readFile("invalid-annotated-pulse.json"), devices);
+			extractPulses(readTestingAsset("invalid-annotated-pulse.json"), devices);
 		}).toThrowError(AnnotatedPulseParsingError);
 	});
 });

--- a/frontend/tests/helpers/data-io.test.ts
+++ b/frontend/tests/helpers/data-io.test.ts
@@ -1,3 +1,4 @@
+import { readTestingAsset } from "@tests/testing-utils";
 import {
 	AnnotatedPulse,
 	AnnotatedPulseParsingError,
@@ -7,7 +8,6 @@ import {
 import { extractPulses, formatFileSize } from "helpers/data-io";
 import { BackendTHzDevice } from "interfaces";
 import { describe, expect, test } from "vitest";
-import { readTestingAsset } from "@tests/testing-utils";
 
 describe("extractPulses", () => {
 	const devices: BackendTHzDevice[] = [

--- a/frontend/tests/testing-utils.tsx
+++ b/frontend/tests/testing-utils.tsx
@@ -1,8 +1,8 @@
+import fs from "fs";
+import path from "path";
 import { MantineProvider } from "@mantine/core";
 import { render as testingLibraryRender } from "@testing-library/react";
 import React from "react";
-import fs from "fs";
-import path from "path";
 
 export * from "@testing-library/react";
 

--- a/frontend/tests/testing-utils.tsx
+++ b/frontend/tests/testing-utils.tsx
@@ -1,6 +1,8 @@
 import { MantineProvider } from "@mantine/core";
 import { render as testingLibraryRender } from "@testing-library/react";
 import React from "react";
+import fs from "fs";
+import path from "path";
 
 export * from "@testing-library/react";
 
@@ -10,4 +12,12 @@ export function render(ui: React.ReactNode) {
 			<MantineProvider>{children}</MantineProvider>
 		),
 	});
+}
+
+export function readTestingAsset(name: string) {
+	const testsFolder = path.resolve(__dirname);
+	return fs.readFileSync(
+		path.join(testsFolder, "testing-assets", name),
+		"utf-8",
+	);
 }


### PR DESCRIPTION
Adds uploading of pulses to backend and closes #18. Specifically
- `integration_time` is renamed to `integration_time_ms`. No need to not be precise.
- integers are coerced to floats for float attributes, since an end-user should be able to upload e.g. an angle of 18 (no dots!), which should be interpreted as a float
