### PR TITLE
added download of annotated pulses compatible with Glaze API

### DIFF
--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -26,6 +26,7 @@ from api.public.attrs.models import (
     get_pulse_attrs_class,
     get_pulse_attrs_read_class,
 )
+from api.public.pulse.helpers import assert_pulses_exist
 from api.public.pulse.models import Pulse
 from api.utils.exceptions import (
     AttrDataTypeExistsError,
@@ -113,27 +114,37 @@ def add_attr(
 
 
 def read_pulse_attrs(
-    pulse_id: UUID,
+    pulse_ids: Sequence[UUID],
     db: Session = Depends(get_session),
-) -> list[TAttrReadDataType]:
+    *,
+    check_pulses_exist: bool = True,
+) -> dict[UUID, list[TAttrReadDataType]]:
     """Get all the keys for a pulse with id pulse_id."""
-    pulse = db.get(Pulse, pulse_id)
+    if check_pulses_exist:
+        assert_pulses_exist(pulse_ids=pulse_ids, db=db)
 
-    attrs_list = []
+    results: dict[UUID, list[TAttrReadDataType]] = {
+        pulse_id: [] for pulse_id in pulse_ids
+    }
 
-    if not pulse:
-        raise PulseNotFoundError(pulse_id=pulse_id)
-
+    # Read attrs for all data types
     for data_type in AttrDataType:
         attrs_class = get_pulse_attrs_class(data_type)
         attrs_read_class = get_pulse_attrs_read_class(data_type)
-        results = db.exec(
-            select(attrs_class).where(attrs_class.pulse_id == pulse_id),
+        loaded_attrs = db.exec(
+            select(attrs_class).where(col(attrs_class.pulse_id).in_(pulse_ids)),
         ).all()
-        attrs = [attrs_read_class.from_orm(obj) for obj in results]
-        attrs_list += attrs
 
-    return attrs_list
+        # Add loaded attrs to results
+        for pulse_id in pulse_ids:
+            for attr in loaded_attrs:
+                # Mypy thinks attr is PulseAttrsBase, which is wrong
+                if attr.pulse_id == pulse_id:  # type: ignore[attr-defined]
+                    results[pulse_id].append(
+                        attrs_read_class.from_orm(attr),
+                    )
+
+    return results
 
 
 def read_all_keys(

--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -20,7 +20,6 @@ from api.utils.exceptions import AttrDataTypeDoesNotExistError
 # See: https://github.com/python/mypy/issues/15238
 TAttrDataType: TypeAlias = StrictStr | StrictFloat
 TAttrDataTypeList: TypeAlias = Sequence[StrictStr] | Sequence[StrictFloat]
-TPulseAttr: TypeAlias = float | str
 
 
 class AttrDict(TypedDict):

--- a/backend/api/public/pulse/helpers.py
+++ b/backend/api/public/pulse/helpers.py
@@ -1,0 +1,28 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from fastapi import Depends
+from sqlmodel import Session, col, select
+
+from api.database import get_session
+from api.public.pulse.models import Pulse
+from api.utils.exceptions import PulseNotFoundError
+
+
+def assert_pulses_exist(
+    pulse_ids: Sequence[UUID],
+    db: Session = Depends(get_session),
+) -> None:
+    """Check that all pulse IDs exist in the database.
+
+    Raises a PulseNotFoundError if not.
+    """
+    existing_pulses = db.exec(
+        select(Pulse.pulse_id).filter(col(Pulse.pulse_id).in_(pulse_ids)),
+    ).all()
+    if len(existing_pulses) != len(pulse_ids):
+        raise PulseNotFoundError(
+            pulse_id=[
+                pulse_id for pulse_id in pulse_ids if pulse_id not in existing_pulses
+            ],
+        )

--- a/backend/api/public/pulse/views.py
+++ b/backend/api/public/pulse/views.py
@@ -12,7 +12,7 @@ from api.public.pulse.crud import (
     read_pulses,
     read_pulses_with_ids,
 )
-from api.public.pulse.models import PulseCreate, PulseRead
+from api.public.pulse.models import AnnotatedPulseRead, PulseCreate, PulseRead
 
 router = APIRouter()
 
@@ -38,7 +38,7 @@ def get_pulses(
 def get_pulses_from_ids(
     ids: list[UUID],
     db: Session = Depends(get_session),
-) -> list[PulseRead]:
+) -> list[AnnotatedPulseRead]:
     return read_pulses_with_ids(ids, db=db)
 
 
@@ -61,5 +61,5 @@ def add_kv_pair(
 def get_pulse_keys(
     pulse_id: UUID,
     db: Session = Depends(get_session),
-) -> list[TAttrReadDataType]:
-    return read_pulse_attrs(pulse_id=pulse_id, db=db)
+) -> dict[UUID, list[TAttrReadDataType]]:
+    return read_pulse_attrs(pulse_ids=[pulse_id], db=db)

--- a/backend/api/utils/exceptions.py
+++ b/backend/api/utils/exceptions.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 class PulseNotFoundError(Exception):
     """Exception raised when the data type of an attribute is not supported."""
 
-    def __init__(self: Self, pulse_id: UUID) -> None:
+    def __init__(self: Self, pulse_id: UUID | list[UUID]) -> None:
         self.pulse_id = pulse_id
         super().__init__(f"Pulse not found with id: {pulse_id}")
 

--- a/backend/api/utils/mock_data_generator.py
+++ b/backend/api/utils/mock_data_generator.py
@@ -19,7 +19,7 @@ def create_devices_and_pulses() -> None:
         device_carmen = create_device(DeviceCreate.create_mock("Carmen"), sess)
 
         pulse_1 = create_pulses(
-            [PulseCreate.create_mock(device_id=device_g_1.device_id)],
+            [PulseCreate.create_mock_w_errs(device_id=device_g_1.device_id)],
             sess,
         )
         pulse_2 = create_pulses(
@@ -30,7 +30,7 @@ def create_devices_and_pulses() -> None:
             [PulseCreate.create_mock(device_id=device_carmen.device_id)],
             sess,
         )
-
+        add_attr(pulse_1[0], PulseAttrsFloatCreate(key="has_errors", value=1.0), sess)
         add_attr(pulse_1[0], PulseAttrsFloatCreate(key="angle", value=29.0), sess)
         add_attr(
             pulse_1[0],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -85,6 +85,9 @@ ignore = [
 "api/**/views.py" = [
   "B008", # To be able to use FastAPI Depends() in function calls
 ]
+"api/**/helpers.py" = [
+  "B008", # To be able to use FastAPI Depends() in function calls
+]
 "api/main.py" = ["ARG001"] # Unused function args
 
 [tool.black]

--- a/backend/tests/api/public/attrs/test_views.py
+++ b/backend/tests/api/public/attrs/test_views.py
@@ -75,14 +75,14 @@ def test_get_attrs_on_pulse(client: TestClient, device_id: UUID) -> None:
     response = client.get(f"/pulses/{pulse_id}/attrs/")
     response_data = response.json()
 
-    response_keys = [d["key"] for d in response_data]
-    response_values = [d["value"] for d in response_data]
+    response_keys = [d["key"] for d in response_data[pulse_id]]
+    response_values = [d["value"] for d in response_data[pulse_id]]
 
     assert pulse_response.status_code == 200
     assert attrs_1_data.status_code == 200
     assert attrs_2_data.status_code == 200
     assert response.status_code == 200
-    assert len(response_data) == 2
+    assert len(response_data[pulse_id]) == 2
     assert attrs_1_payload["key"] in response_keys
     assert attrs_2_payload["key"] in response_keys
     assert attrs_1_payload["value"] in response_values
@@ -97,7 +97,7 @@ def test_get_pulse_attrs_on_non_existing_pulse(client: TestClient) -> None:
     response_data = response.json()
 
     assert response.status_code == 404
-    assert response_data["detail"] == f"Pulse not found with id: {pulse_id}"
+    assert response_data["detail"] == f"Pulse not found with id: [UUID('{pulse_id}')]"
 
 
 def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: UUID) -> None:
@@ -121,13 +121,13 @@ def test_add_pulse_attrs_on_pulse(client: TestClient, device_id: UUID) -> None:
     response = client.get(f"/pulses/{pulse_id}/attrs/")
     response_data = response.json()
 
-    response_keys = [d["key"] for d in response_data]
-    response_values = [d["value"] for d in response_data]
+    response_keys = [d["key"] for d in response_data[pulse_id]]
+    response_values = [d["value"] for d in response_data[pulse_id]]
 
     assert pulse_response.status_code == 200
     assert attrs_response.status_code == 200
     assert response.status_code == 200
-    assert len(response_data) == 1
+    assert len(response_data[pulse_id]) == 1
     assert attrs_payload["key"] in response_keys
     assert attrs_payload["value"] in response_values
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { setupCache } from "axios-cache-interceptor";
-import { AnnotatedPulse, FilterResult, Pulse, attrKeyFactory } from "classes";
+import { AnnotatedPulse, FilterResult, attrKeyFactory } from "classes";
 import { getBackendUrl, sortPulseFilters } from "helpers";
 import {
 	BackendAttrKey,
@@ -56,34 +56,15 @@ export async function getFilteredPulses(
 		});
 }
 
-export async function getPulse(pulseID: PulseID): Promise<Pulse> {
-	return api.get<BackendPulse>(`/pulses/${pulseID}`).then((resp) => {
-		return new Pulse(
-			resp.data.delays,
-			resp.data.signal,
-			resp.data.integration_time,
-			new Date(resp.data.creation_time),
-			resp.data.pulse_id,
-		);
-	});
-}
-
-export async function getPulses(pulseIDs: PulseID[]): Promise<Pulse[]> {
+export async function getPulses(
+	pulseIDs: PulseID[],
+): Promise<AnnotatedPulse[]> {
 	return (
 		api
 			// sort pulse IDs for improved caching
 			.post<BackendPulse[]>("/pulses/get", [...pulseIDs].sort())
 			.then((resp) => {
-				return resp.data.map(
-					(el: BackendPulse) =>
-						new Pulse(
-							el.delays,
-							el.signal,
-							el.integration_time,
-							new Date(el.creation_time),
-							el.pulse_id,
-						),
-				);
+				return resp.data.map(AnnotatedPulse.fromBackendPulse);
 			})
 	);
 }

--- a/frontend/src/classes/Pulse.ts
+++ b/frontend/src/classes/Pulse.ts
@@ -61,7 +61,7 @@ export class AnnotatedPulse {
 			{
 				time: parsed.pulse.time,
 				signal: parsed.pulse.signal,
-				signal_err: parsed.pulse.signal_err,
+				signal_err: parsed.pulse.signal_err ? parsed.pulse.signal_err : null,
 			},
 			parsed.integration_time_ms,
 			creationTime,

--- a/frontend/src/classes/Pulse.ts
+++ b/frontend/src/classes/Pulse.ts
@@ -1,28 +1,34 @@
-import { BackendTHzDevice, PulseID } from "interfaces";
+import { BackendPulse, BackendTHzDevice } from "interfaces";
 import { z } from "zod";
-
-export class Pulse {
-	constructor(
-		public time: number[],
-		public signal: number[],
-		public integrationTime: number,
-		public creationTime: Date,
-		public ID: PulseID,
-	) {}
-}
 
 export class AnnotatedPulse {
 	constructor(
 		public pulse: {
 			time: number[];
 			signal: number[];
-			signal_err?: number[] | null;
+			signal_err: number[] | null;
 		},
 		public integration_time_ms: number,
 		public creation_time: Date,
 		public device_id: string,
 		public pulse_attributes: { key: string; value: string | number }[],
+		public pulse_id?: string,
 	) {}
+
+	static fromBackendPulse(pulse: BackendPulse): AnnotatedPulse {
+		return new AnnotatedPulse(
+			{
+				time: pulse.delays,
+				signal: pulse.signal,
+				signal_err: pulse.signal_error,
+			},
+			pulse.integration_time_ms,
+			new Date(pulse.creation_time),
+			pulse.device_id,
+			pulse.pulse_attributes,
+			pulse.pulse_id,
+		);
+	}
 
 	static validateAndParse(
 		data: unknown,

--- a/frontend/src/components/MatchingPulses.tsx
+++ b/frontend/src/components/MatchingPulses.tsx
@@ -1,8 +1,8 @@
 import * as M from "@mantine/core";
 import { useDisclosure, useListState } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
-import { getFilteredPulses, getPulse, getPulses } from "api";
-import { Pulse } from "classes";
+import { getFilteredPulses, getPulses } from "api";
+import { AnnotatedPulse } from "classes";
 import { downloadJson } from "helpers";
 import { PulseMetadata } from "interfaces";
 import { useEffect, useState } from "react";
@@ -17,11 +17,11 @@ function PulseCard({
 	isSelected: boolean;
 	setSelected: (value: React.SetStateAction<PulseMetadata | null>) => void;
 }) {
-	const [pulse, setPulse] = useState<Pulse | null>(null);
+	const [pulse, setPulse] = useState<AnnotatedPulse | null>(null);
 
 	useEffect(() => {
 		if (isSelected) {
-			getPulse(pulseMetadata.pulseID).then((p) => setPulse(p));
+			getPulses([pulseMetadata.pulseID]).then((p) => setPulse(p[0]));
 		}
 	}, [isSelected]);
 
@@ -54,10 +54,10 @@ function PulseCard({
 				</M.Card>
 			</M.Popover.Target>
 			<M.Popover.Dropdown>
-				<M.Text>Datapoints: {pulse?.time.length}</M.Text>
-				<M.Text>Integration Time: {pulse?.integrationTime} ms</M.Text>
+				<M.Text>Datapoints: {pulse?.pulse.time.length}</M.Text>
+				<M.Text>Integration Time: {pulse?.integration_time_ms} ms</M.Text>
 				<M.Text>
-					Creation Time: {pulse?.creationTime.toLocaleDateString("en-GB")}
+					Creation Time: {pulse?.creation_time.toLocaleDateString("en-GB")}
 				</M.Text>
 			</M.Popover.Dropdown>
 		</M.Popover>

--- a/frontend/src/interfaces/backend.ts
+++ b/frontend/src/interfaces/backend.ts
@@ -1,13 +1,19 @@
 import { KVType, PulseID } from "interfaces";
 
-export type BackendPulseAttrValues = string[] | number[];
+export interface BackendPulseAttr {
+	key: string;
+	value: string | number;
+}
 
 export interface BackendPulse {
 	delays: number[];
 	signal: number[];
-	integration_time: number;
+	signal_error: number[] | null;
+	integration_time_ms: number;
 	creation_time: string;
 	pulse_id: PulseID;
+	device_id: string;
+	pulse_attributes: BackendPulseAttr[];
 }
 export interface BackendAttrKey {
 	name: string;

--- a/frontend/tests/api/index.test.ts
+++ b/frontend/tests/api/index.test.ts
@@ -1,7 +1,8 @@
 import { readTestingAsset } from "@tests/testing-utils";
-import { getFilteredPulses, getPulseKeys } from "api";
+import { getFilteredPulses, getPulseKeys, getPulses } from "api";
 import { uploadPulses } from "api";
 import {
+	AnnotatedPulse,
 	DateAttrKey,
 	FilterResult,
 	PulseDateFilter,
@@ -93,5 +94,25 @@ describe("uploadPulses", () => {
 			expect(result.length).toBe(pulses.length);
 			expect(typeof result[0]).toBe("string");
 		}
+	});
+});
+
+describe("getPulses", () => {
+	test("should return annotated pulses", async () => {
+		const allPulses = await getFilteredPulses([]);
+		const downloadablePulses = await getPulses(
+			allPulses.pulsesMetadata.map((p) => p.pulseID).slice(0, 5),
+		);
+		downloadablePulses.forEach((pulse) => {
+			expect(pulse).toBeInstanceOf(AnnotatedPulse);
+			expect(pulse.pulse.time).toBeDefined();
+			expect(pulse.pulse.signal).toBeDefined();
+			expect(pulse.pulse.signal_err).toBeDefined();
+			expect(pulse.pulse_attributes).toBeDefined();
+			expect(pulse.device_id).toBeDefined();
+			expect(pulse.integration_time_ms).toBeDefined();
+			expect(pulse.pulse).toBeDefined();
+			expect(pulse.pulse_id).toBeDefined();
+		});
 	});
 });

--- a/frontend/tests/classes/Pulse.test.ts
+++ b/frontend/tests/classes/Pulse.test.ts
@@ -21,6 +21,20 @@ describe("AnnotatedPulse", () => {
 			{ key: "key2", value: 2 },
 		],
 	};
+	const validPulseWSigErrors = {
+		pulse: {
+			time: [1, 2, 3],
+			signal: [0.1, 0.2, 0.3],
+			signal_err: [0.01, 0.02, 0.03],
+		},
+		integration_time_ms: 100,
+		creation_time: "2023-11-19T01:30:10.175Z",
+		device_id: "someID",
+		pulse_attributes: [
+			{ key: "key1", value: "value1" },
+			{ key: "key2", value: 2 },
+		],
+	};
 	const devices = [
 		{ device_id: "someID", friendly_name: "someName" } as BackendTHzDevice,
 	];
@@ -32,7 +46,10 @@ describe("AnnotatedPulse", () => {
 		);
 
 		expect(annotatedPulse).toBeInstanceOf(AnnotatedPulse);
-		expect(annotatedPulse.pulse).toEqual(validAnnotatedPulse.pulse);
+		expect(annotatedPulse.pulse.time).toEqual(validAnnotatedPulse.pulse.time);
+		expect(annotatedPulse.pulse.signal).toEqual(
+			validAnnotatedPulse.pulse.signal,
+		);
 		expect(annotatedPulse.integration_time_ms).toEqual(
 			validAnnotatedPulse.integration_time_ms,
 		);
@@ -42,6 +59,18 @@ describe("AnnotatedPulse", () => {
 		expect(annotatedPulse.device_id).toEqual(validAnnotatedPulse.device_id);
 		expect(annotatedPulse.pulse_attributes).toEqual(
 			validAnnotatedPulse.pulse_attributes,
+		);
+	});
+
+	test("should create an instance of AnnotatedPulse with errors", () => {
+		const annotatedPulse = AnnotatedPulse.validateAndParse(
+			validPulseWSigErrors,
+			devices,
+		);
+
+		expect(annotatedPulse).toBeInstanceOf(AnnotatedPulse);
+		expect(annotatedPulse.pulse.signal_err).toEqual(
+			validPulseWSigErrors.pulse.signal_err,
 		);
 	});
 

--- a/frontend/tests/helpers/data-io.test.ts
+++ b/frontend/tests/helpers/data-io.test.ts
@@ -28,6 +28,15 @@ describe("extractPulses", () => {
 		expect(result.length).toBe(1);
 	});
 
+	test("should extract single pulse with errors from file content succesfully", () => {
+		const fileContent = readTestingAsset(
+			"valid-annotated-pulse-with-error.json",
+		);
+		const result = extractPulses(fileContent, devices);
+		expect(result.every((item) => item instanceof AnnotatedPulse)).toBe(true);
+		expect(result.length).toBe(1);
+	});
+
 	test("should extract pulses from array in file content succesfully", () => {
 		const fileContent = readTestingAsset("valid-annotated-pulse-list.json");
 		const result = extractPulses(fileContent, devices);

--- a/frontend/tests/testing-assets/valid-annotated-pulse-with-error.json
+++ b/frontend/tests/testing-assets/valid-annotated-pulse-with-error.json
@@ -1,0 +1,20 @@
+{
+	"pulse": {
+		"time": [1, 2, 3],
+		"signal": [1, 2, 3],
+		"signal_err": [1, 2, 3]
+	},
+	"integration_time_ms": 30,
+	"creation_time": "2023-11-19T01:30:10.175500",
+	"device_id": "5042dbda-e9bc-4216-a614-ac56d0a32023",
+	"pulse_attributes": [
+		{
+			"key": "project",
+			"value": "ACME"
+		},
+		{
+			"key": "angle",
+			"value": 17
+		}
+	]
+}


### PR DESCRIPTION
Adds downloading of annotated pulses compatible with the format expected by the [Glaze API](https://github.com/GlazeTech/App). Together with GlazeTech/App#44, this closes #77.

The PR changes `read_pulse_attrs` to load attrs from many pulses instead of a single pulse to reduce the number of DB transactions. When reading specific pulses from the DB, the endpoint `pulses/get` now returns a list of annotated pulses instead of a list of pulses without annotation. 

Finally, a few lines of unused code are removed. 