### PR TITLE
Frontend access control scaffold

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "immer": "^10.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.20.1",
         "zod": "^3.22.4",
         "zustand": "^4.4.4"
       },
@@ -895,6 +896,14 @@
       "integrity": "sha512-j8vR8whB332pGI8OXkM2/3rdh4LJxELJQTG+rTsCCd3VQuEJiRTQDKVaOvp9ONja3GU5b1Tk3zhKOrkpgxTJBA==",
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
+      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3189,6 +3198,36 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
+      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
+      "dependencies": {
+        "@remix-run/router": "1.13.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
+      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
+      "dependencies": {
+        "@remix-run/router": "1.13.1",
+        "react-router": "6.20.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "immer": "^10.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1",
     "zod": "^3.22.4",
     "zustand": "^4.4.4"
   },

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -11,6 +11,8 @@ import {
 } from "interfaces";
 import { BackendTHzDevice } from "interfaces/backend";
 
+// TODO: Add interceptor which refreshes token if it is expired
+// See this: https://www.thedutchlab.com/en/insights/using-axios-interceptors-for-refreshing-your-api-token
 const api = setupCache(
 	axios.create({
 		baseURL: getBackendUrl(),

--- a/frontend/src/auth/accessToken.ts
+++ b/frontend/src/auth/accessToken.ts
@@ -1,0 +1,43 @@
+import { AuthLevel } from "interfaces";
+import { refreshAccessToken } from "./auth-service";
+
+// Use a global variable to store a JWT token used for authentication.
+let accessToken: string | null = "fake-access-token";
+
+export const getAccessToken = async () => {
+	// If we already have an access token, we return it immediately.
+	if (accessToken) {
+		return accessToken;
+	}
+
+	// If page is refreshed (access token is lost), try to refresh access token.
+	refreshAccessToken()
+		.then((token) => {
+			setAccessToken(token);
+			return token;
+		})
+		.catch(() => {
+			return accessToken;
+		});
+};
+
+export const setAccessToken = (token: string) => {
+	accessToken = token;
+};
+
+export const clearAccessToken = () => {
+	accessToken = null;
+};
+
+export const getAuthLevel = async () => {
+	return getAccessToken().then((token) => {
+		if (!token) {
+			return AuthLevel.UNAUTHORIZED;
+		}
+
+		// TODO: Implement decoding.
+		// decodedToken = decodeToken(token);
+		// authLevel = decodedToken.authLevel;
+		return AuthLevel.ADMIN;
+	});
+};

--- a/frontend/src/auth/auth-service.ts
+++ b/frontend/src/auth/auth-service.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+import { getBackendUrl } from "helpers";
+import { clearAccessToken } from "./accessToken";
+
+const authService = axios.create({
+	baseURL: getBackendUrl(),
+});
+
+// export async function login(username: string, password: string) {
+// 	return authService
+// 		.post("/auth/login", {
+// 			email,
+// 			password,
+// 		})
+// 		.then((resp) => {
+// 			setAccessToken(resp.data.accessToken);
+// 			return resp.data.accessToken;
+// 		});
+// }
+
+export async function login(_: string, __: string): Promise<string> {
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve("fake-access-token");
+		}, 1000);
+	});
+}
+
+export async function refreshAccessToken(): Promise<string> {
+	return authService.get("/auth/refresh").then((resp) => {
+		return resp.data.accessToken;
+	});
+}
+
+// export function register(email: string, password: string): Promise<void> {
+// 	return authService.post("/auth/register", {
+// 		email,
+// 		password,
+// 	});
+// }
+
+export function register(_: string, __: string): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, 1000);
+	});
+}
+
+// export async function logout(): Promise<void> {
+// 	clearAccessToken();
+// 	return authService.post("/auth/logout");
+// }
+
+export async function logout(): Promise<void> {
+	clearAccessToken();
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, 100);
+	});
+}

--- a/frontend/src/auth/index.ts
+++ b/frontend/src/auth/index.ts
@@ -1,0 +1,2 @@
+export * from "./accessToken";
+export * from "./auth-service";

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,0 +1,4 @@
+export default function AdminDashboard() {
+	// TODO: Implement a list of all users, where we can change their roles.
+	return <div>Dashboard</div>;
+}

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -1,13 +1,8 @@
-import "@mantine/core/styles.css";
-import "@mantine/dates/styles.css";
-import "@mantine/dropzone/styles.css";
-import "@mantine/notifications/styles.css";
-
-import { AppShell, Divider, MantineProvider } from "@mantine/core";
-import { Notifications } from "@mantine/notifications";
+import { AppShell, Divider } from "@mantine/core";
 import { useEffect } from "react";
 import { useStoreShallow } from "store";
 import FilterMenu from "./FilterMenu";
+import Header from "./Header";
 import MatchingPulses from "./MatchingPulses";
 import PulseUploader from "./PulseUploader";
 import RecommendedFilters from "./RecommendedFilters";
@@ -20,26 +15,26 @@ function App() {
 	}, []);
 
 	return (
-		<MantineProvider defaultColorScheme="auto">
-			<Notifications position="top-right" />
-			<AppShell
-				navbar={{ width: 250, breakpoint: "xs" }}
-				aside={{ width: 250, breakpoint: "xs" }}
-			>
-				<AppShell.Header> </AppShell.Header>
-				<AppShell.Navbar>
-					<PulseUploader />
-					<Divider m={5} />
-					<FilterMenu />
-				</AppShell.Navbar>
-				<AppShell.Main>
-					<RecommendedFilters />
-				</AppShell.Main>
-				<AppShell.Aside>
-					<MatchingPulses />
-				</AppShell.Aside>
-			</AppShell>
-		</MantineProvider>
+		<AppShell
+			header={{ height: 50 }}
+			navbar={{ width: 250, breakpoint: "xs" }}
+			aside={{ width: 250, breakpoint: "xs" }}
+		>
+			<AppShell.Header>
+				<Header />
+			</AppShell.Header>
+			<AppShell.Navbar>
+				<PulseUploader />
+				<Divider m={5} />
+				<FilterMenu />
+			</AppShell.Navbar>
+			<AppShell.Main>
+				<RecommendedFilters />
+			</AppShell.Main>
+			<AppShell.Aside>
+				<MatchingPulses />
+			</AppShell.Aside>
+		</AppShell>
 	);
 }
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import { Button, Group } from "@mantine/core";
+import { logout } from "auth";
+import { useState } from "react";
+import { Navigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
+
+enum LoginStatus {
+	LoggedIn = 1,
+	LoggedOut = 2,
+}
+
+export default function Header() {
+	const [loginStatus, setLoginStatus] = useState(LoginStatus.LoggedIn);
+	const location = useLocation();
+
+	const handleLogout = () => {
+		logout().then(() => {
+			setLoginStatus(LoginStatus.LoggedOut);
+		});
+	};
+
+	if (loginStatus === LoginStatus.LoggedIn) {
+		return (
+			<Group justify="right">
+				<Button mt={7} variant="subtle" onClick={handleLogout}>
+					Log out
+				</Button>
+			</Group>
+		);
+	} else if (loginStatus === LoginStatus.LoggedOut) {
+		return <Navigate to={"/login"} state={{ from: location }} replace />;
+	}
+}

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -56,9 +56,11 @@ export function uniqueElements<T>(list: T[]): T[] {
 
 export function getBackendUrl(): string {
 	// import.meta.env.* is only available in production
-	if (import.meta.env.PROD) {
-		return import.meta.env.VITE_BACKEND_URL;
-	}
+	try {
+		if (import.meta.env.PROD) {
+			return import.meta.env.VITE_BACKEND_URL;
+		}
+	} catch (e) {}
 
 	// for test runs, URL is injected via environment variables - this won't be available in a browser
 	try {

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -1,0 +1,19 @@
+import { getAuthLevel } from "auth";
+import { useEffect, useState } from "react";
+
+export enum AuthLevel {
+	LOADING = 1,
+	UNAUTHORIZED = 2,
+	USER = 3,
+	ADMIN = 4,
+}
+
+export function useIsAuthorized() {
+	const [authLevel, setAuthLevel] = useState(AuthLevel.LOADING);
+
+	useEffect(() => {
+		getAuthLevel().then((level) => setAuthLevel(level));
+	}, []);
+
+	return authLevel;
+}

--- a/frontend/src/interfaces/auth.ts
+++ b/frontend/src/interfaces/auth.ts
@@ -1,0 +1,6 @@
+export enum AuthLevel {
+	LOADING = 1,
+	UNAUTHORIZED = 2,
+	USER = 3,
+	ADMIN = 4,
+}

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from "./backend";
 export * from "./mantine";
+export * from "./auth";
 
 export enum KVType {
 	NUMBER = "float",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,21 @@
-import App from "components/App.tsx";
+import { MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css";
+import "@mantine/dropzone/styles.css";
+import { Notifications } from "@mantine/notifications";
+import "@mantine/notifications/styles.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import { router } from "router";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as Element);
 
 root.render(
 	<React.StrictMode>
-		<App />
+		<MantineProvider defaultColorScheme="auto">
+			<Notifications position="top-right" />
+			<RouterProvider router={router} />
+		</MantineProvider>
 	</React.StrictMode>,
 );

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,0 +1,19 @@
+import { LoadingOverlay } from "@mantine/core";
+import AdminDashboard from "components/AdminDashboard";
+import { AuthLevel, useIsAuthorized } from "hooks";
+import { Navigate, useLocation } from "react-router-dom";
+
+export default function Admin() {
+	const authLevel = useIsAuthorized();
+	const location = useLocation();
+
+	if (authLevel === AuthLevel.LOADING) {
+		return <LoadingOverlay visible />;
+	} else if (authLevel === AuthLevel.UNAUTHORIZED) {
+		return <Navigate to="/login" state={{ from: location }} replace />;
+	} else if (authLevel === AuthLevel.USER) {
+		return <Navigate to="/" state={{ from: location }} replace />;
+	} else if (authLevel === AuthLevel.ADMIN) {
+		return <AdminDashboard />;
+	}
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,17 @@
+import { LoadingOverlay } from "@mantine/core";
+import App from "components/App";
+import { AuthLevel, useIsAuthorized } from "hooks";
+import { Navigate, useLocation } from "react-router-dom";
+
+export default function Home() {
+	const authLevel = useIsAuthorized();
+	const location = useLocation();
+
+	if (authLevel === AuthLevel.LOADING) {
+		return <LoadingOverlay visible />;
+	} else if (authLevel === AuthLevel.UNAUTHORIZED) {
+		return <Navigate to="/login" state={{ from: location }} replace />;
+	} else if (authLevel >= AuthLevel.USER) {
+		return <App />;
+	}
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,105 @@
+import {
+	Box,
+	Button,
+	Card,
+	LoadingOverlay,
+	Stack,
+	TextInput,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { register } from "auth";
+import { FormEvent, useState } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+
+enum SignupStatus {
+	NOT_REGISTERED = 1,
+	REGISTERING = 2,
+	REGISTERED = 3,
+	REDIRECTING = 4,
+}
+
+const style = {
+	alignItems: "center",
+};
+
+export default function Register() {
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const location = useLocation();
+
+	const [signupStatus, setSignupStatus] = useState(SignupStatus.NOT_REGISTERED);
+
+	const handleRegister = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		setSignupStatus(SignupStatus.REGISTERING);
+		const refreshDuration = 1500;
+		register(email, password)
+			.then(() => {
+				setSignupStatus(SignupStatus.REGISTERED);
+				notifications.show({
+					title: "Success",
+					message:
+						"Registration succesful! Once you are approved by an administrator, you will be able to log in.",
+					autoClose: refreshDuration,
+					color: "green",
+				});
+				setTimeout(() => {
+					setSignupStatus(SignupStatus.REDIRECTING);
+				}, refreshDuration);
+			})
+			.catch((err) => {
+				setSignupStatus(SignupStatus.NOT_REGISTERED);
+				notifications.show({
+					title: "Error",
+					message: err.message,
+					color: "red",
+				});
+			});
+	};
+
+	if (signupStatus !== SignupStatus.REDIRECTING) {
+		return (
+			<Stack style={style} mt={100}>
+				<h1>Welcome to TeraStore</h1>
+				<Card
+					shadow="xl"
+					withBorder
+					padding="xl"
+					style={{ minWidth: 400 }}
+					pos={"relative"}
+				>
+					<LoadingOverlay visible={signupStatus === SignupStatus.REGISTERING} />
+					<h2>Create Account</h2>
+					<form onSubmit={handleRegister}>
+						<TextInput
+							required
+							type="email"
+							placeholder="Email"
+							value={email}
+							onChange={(event) => setEmail(event.currentTarget.value)}
+							pt={10}
+							pb={10}
+						/>
+						<TextInput
+							required
+							type="password"
+							placeholder="Password"
+							value={password}
+							onChange={(event) => setPassword(event.currentTarget.value)}
+							pt={10}
+							pb={10}
+						/>
+						<Button type="submit" fullWidth pt={10} pb={10}>
+							Register
+						</Button>
+						<Box pt={20}>
+							<Link to="/login">Already have an account? Sign in</Link>
+						</Box>
+					</form>
+				</Card>
+			</Stack>
+		);
+	} else if (signupStatus === SignupStatus.REDIRECTING) {
+		return <Navigate to={"/login"} state={{ from: location }} replace />;
+	}
+}

--- a/frontend/src/pages/Signin.tsx
+++ b/frontend/src/pages/Signin.tsx
@@ -1,0 +1,97 @@
+import {
+	Box,
+	Button,
+	Card,
+	LoadingOverlay,
+	Stack,
+	TextInput,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { login, setAccessToken } from "auth";
+import { FormEvent, useState } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+
+enum SigninStatus {
+	NOT_LOGGED_IN = 1,
+	LOGGING_IN = 2,
+	LOGGED_IN = 3,
+}
+
+const style = {
+	alignItems: "center",
+};
+
+export default function Signin() {
+	const [username, setUsername] = useState("");
+	const [password, setPassword] = useState("");
+	const location = useLocation();
+
+	const [signinStatus, setSigninStatus] = useState(SigninStatus.NOT_LOGGED_IN);
+
+	const handleLogin = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		setSigninStatus(SigninStatus.LOGGING_IN);
+		login(username, password)
+			.then((token) => {
+				setAccessToken(token);
+				setSigninStatus(SigninStatus.LOGGED_IN);
+			})
+			.catch((err) => {
+				setSigninStatus(SigninStatus.NOT_LOGGED_IN);
+				notifications.show({
+					title: "Error",
+					message: err.message,
+					color: "red",
+				});
+			});
+	};
+
+	if (
+		signinStatus === SigninStatus.NOT_LOGGED_IN ||
+		signinStatus === SigninStatus.LOGGING_IN
+	) {
+		return (
+			<Stack style={style} mt={100}>
+				<h1>Welcome to TeraStore</h1>
+				<Card
+					shadow="xl"
+					withBorder
+					padding="xl"
+					style={{ minWidth: 400 }}
+					pos={"relative"}
+				>
+					<LoadingOverlay visible={signinStatus === SigninStatus.LOGGING_IN} />
+					<h2>Sign in</h2>
+					<form onSubmit={handleLogin}>
+						<TextInput
+							required
+							type="email"
+							placeholder="Email"
+							value={username}
+							onChange={(event) => setUsername(event.currentTarget.value)}
+							pt={10}
+							pb={10}
+						/>
+						<TextInput
+							required
+							type="password"
+							placeholder="Password"
+							value={password}
+							onChange={(event) => setPassword(event.currentTarget.value)}
+							pt={10}
+							pb={10}
+						/>
+						<Button type="submit" fullWidth pt={10} pb={10}>
+							Sign in
+						</Button>
+						<Box pt={20}>
+							<Link to="/register">Create an account</Link>
+						</Box>
+					</form>
+				</Card>
+			</Stack>
+		);
+	} else if (signinStatus === SigninStatus.LOGGED_IN) {
+		return <Navigate to={"/"} state={{ from: location }} replace />;
+	}
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,24 @@
+import Admin from "pages/Admin";
+import Home from "pages/Home";
+import Register from "pages/Register";
+import Signin from "pages/Signin";
+import { createBrowserRouter } from "react-router-dom";
+
+export const router = createBrowserRouter([
+	{
+		path: "/",
+		element: <Home />,
+	},
+	{
+		path: "/login",
+		element: <Signin />,
+	},
+	{
+		path: "/register",
+		element: <Register />,
+	},
+	{
+		path: "/admin",
+		element: <Admin />,
+	},
+]);


### PR DESCRIPTION
This PR scaffolds access control on the frontend. It adds
- a login route
- a register route
- an admin route
- an app route
- access control with a dummy access token.

Routing is managed with [React Router](https://reactrouter.com/en/main) and authorisation is managed with a [JSON Web Token](https://jwt.io/) (JWT)