### PR TITLE
Updated dependencies to match SQLModel 0.0.14

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1,7 +1,7 @@
 import os
 from functools import lru_cache
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 def get_env_var(var_name: str) -> str:
@@ -14,8 +14,8 @@ def get_env_var(var_name: str) -> str:
 
 
 class Settings(BaseSettings):
-    PROJECT_NAME = "TeraStore API"
-    DATABASE_URL = get_env_var("DATABASE_URL")
+    PROJECT_NAME: str = "TeraStore API"
+    DATABASE_URL: str = get_env_var("DATABASE_URL")
 
 
 @lru_cache

--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -140,7 +140,7 @@ def read_pulse_attrs(
                 # Mypy thinks attr is PulseAttrsBase, which is wrong
                 if attr.pulse_id == pulse_id:  # type: ignore[attr-defined]
                     results[pulse_id].append(
-                        attrs_read_class.from_orm(attr),
+                        attrs_read_class.model_validate(attr),
                     )
 
     return results

--- a/backend/api/public/attrs/models.py
+++ b/backend/api/public/attrs/models.py
@@ -9,7 +9,8 @@ from enum import Enum
 from typing import Self, TypeAlias, TypedDict
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
+from pydantic.functional_validators import field_validator
 from pydantic.types import StrictFloat, StrictInt, StrictStr
 from sqlmodel import Field, SQLModel
 
@@ -98,7 +99,7 @@ class PulseAttrsFloat(PulseAttrsBase, table=True):
 
     index: UUID = Field(default_factory=uuid4, primary_key=True)
 
-    @validator("value", pre=True)
+    @field_validator("value", mode="before")
     def allow_ints(cls: type[PulseAttrsFloat], v: object) -> object:  # noqa: N805
         # Allow ints to be used as floats. We cannot simply annotate `value`,
         # as PostgreSQL have separated types for int and float.

--- a/backend/api/public/device/crud.py
+++ b/backend/api/public/device/crud.py
@@ -12,11 +12,11 @@ def create_device(
     device: DeviceCreate | Device,
     db: Session = Depends(get_session),
 ) -> DeviceRead:
-    device_to_db = Device.from_orm(device)
+    device_to_db = Device.model_validate(device)
     db.add(device_to_db)
     db.commit()
     db.refresh(device_to_db)
-    return DeviceRead.from_orm(device_to_db)
+    return DeviceRead.model_validate(device_to_db)
 
 
 def read_devices(
@@ -25,11 +25,11 @@ def read_devices(
     db: Session = Depends(get_session),
 ) -> list[DeviceRead]:
     devices = db.exec(select(Device).offset(offset).limit(limit)).all()
-    return [DeviceRead.from_orm(device) for device in devices]
+    return [DeviceRead.model_validate(device) for device in devices]
 
 
 def read_device(device_id: UUID, db: Session = Depends(get_session)) -> DeviceRead:
     device = db.get(Device, device_id)
     if not device:
         raise DeviceNotFoundError(device_id=device_id)
-    return DeviceRead.from_orm(device)
+    return DeviceRead.model_validate(device)

--- a/backend/api/public/device/models.py
+++ b/backend/api/public/device/models.py
@@ -43,7 +43,7 @@ class DeviceCreate(DeviceBase):
         return cls(friendly_name=friendly_name)
 
     def as_dict(self: Self) -> dict[str, str]:
-        return self.dict()
+        return self.model_dump()
 
 
 class DeviceRead(DeviceBase):

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -76,7 +76,7 @@ def read_pulses(
 ) -> list[PulseRead]:
     """Get all pulses in the database."""
     pulses = db.exec(select(Pulse).offset(offset).limit(limit)).all()
-    return [PulseRead.from_orm(pulse) for pulse in pulses]
+    return [PulseRead.model_validate(pulse) for pulse in pulses]
 
 
 def read_pulses_with_ids(
@@ -115,4 +115,4 @@ def read_pulse(pulse_id: UUID, db: Session = Depends(get_session)) -> PulseRead:
     pulse = db.get(Pulse, pulse_id)
     if not pulse:
         raise PulseNotFoundError(pulse_id=pulse_id)
-    return PulseRead.from_orm(pulse)
+    return PulseRead.model_validate(pulse)

--- a/backend/api/public/pulse/models.py
+++ b/backend/api/public/pulse/models.py
@@ -49,7 +49,10 @@ class PulseBase(SQLModel):
 
     delays: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
     signal: list[float] = Field(sa_column=Column(postgresql.ARRAY(Float)))
-    signal_error: list[float] | None = Field(sa_column=Column(postgresql.ARRAY(Float)))
+    signal_error: list[float] | None = Field(
+        default=None,
+        sa_column=Column(postgresql.ARRAY(Float)),
+    )
     integration_time_ms: int
     creation_time: datetime
     device_id: UUID = Field(foreign_key="devices.device_id")
@@ -142,7 +145,7 @@ class PulseCreate(PulseBase):
         }
 
     def create_pulse(self: Self) -> tuple[Pulse, PulseAttrs]:
-        pulse = Pulse.create(self.dict(exclude={"pulse_attributes"}))
+        pulse = Pulse.create(self.model_dump(exclude={"pulse_attributes"}))
         pulse_attributes = PulseAttrs(
             pulse_id=pulse.pulse_id,
             pulse_attributes=self.pulse_attributes,
@@ -176,7 +179,7 @@ class AnnotatedPulseRead(PulseBase):
         pulse: Pulse,
         attrs: list[TAttrReadDataType],
     ) -> AnnotatedPulseRead:
-        return cls(**pulse.dict(), pulse_attributes=attrs)
+        return cls(**pulse.model_dump(), pulse_attributes=attrs)
 
 
 class TemporaryPulseIdTable(SQLModel, table=True):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,26 +10,28 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-  "fastapi[all]==0.99.1",
-  "sqlmodel==0.0.12",
+  "fastapi[all]==0.104.1",
+  "sqlmodel==0.0.14",
+  "pydantic==2.5.2",
+  "pydantic-settings==2.1.0",
   "psycopg2-binary==2.9.9",
 ]
 
 [project.optional-dependencies]
 test = [
-  "mypy==1.7.0",
+  "mypy==1.7.1",
   "black==23.11.0",
-  "ruff==0.1.6",
+  "ruff==0.1.7",
   "pytest==7.4.3",
-  "types-psycopg2==2.9.21.16",
+  "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
 ]
 dev = [
-  "mypy==1.7.0",
+  "mypy==1.7.1",
   "black==23.11.0",
-  "ruff==0.1.6",
+  "ruff==0.1.7",
   "pytest==7.4.3",
-  "types-psycopg2==2.9.21.16",
+  "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
 ]
 
@@ -48,6 +50,7 @@ no_implicit_reexport = true
 no_implicit_optional = true
 disallow_untyped_defs = true
 show_error_codes = true
+
 
 [tool.pydantic-mypy]
 init_forbid_extra = true

--- a/backend/tests/api/public/device/test_views.py
+++ b/backend/tests/api/public/device/test_views.py
@@ -27,8 +27,8 @@ def test_create_device_with_invalid_friendly_name(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "str type expected"
-    assert data["detail"][0]["type"] == "type_error.str"
+    assert data["detail"][0]["msg"] == "Input should be a valid string"
+    assert data["detail"][0]["type"] == "string_type"
 
 
 def test_create_device_with_extra_params(client: TestClient) -> None:
@@ -40,8 +40,8 @@ def test_create_device_with_extra_params(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "extra fields not permitted"
-    assert data["detail"][0]["type"] == "value_error.extra"
+    assert data["detail"][0]["msg"] == "Extra inputs are not permitted"
+    assert data["detail"][0]["type"] == "extra_forbidden"
 
 
 def test_create_device_with_empty_body(client: TestClient) -> None:
@@ -53,8 +53,8 @@ def test_create_device_with_empty_body(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "field required"
-    assert data["detail"][0]["type"] == "value_error.missing"
+    assert data["detail"][0]["msg"] == "Field required"
+    assert data["detail"][0]["type"] == "missing"
 
 
 def test_create_device_with_invalid_device_id(client: TestClient) -> None:
@@ -69,8 +69,8 @@ def test_create_device_with_invalid_device_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "extra fields not permitted"
-    assert data["detail"][0]["type"] == "value_error.extra"
+    assert data["detail"][0]["msg"] == "Extra inputs are not permitted"
+    assert data["detail"][0]["type"] == "extra_forbidden"
 
 
 def test_get_device(client: TestClient) -> None:
@@ -99,8 +99,11 @@ def test_get_device_with_invalid_device_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid uuid"
-    assert data["detail"][0]["type"] == "type_error.uuid"
+    assert data["detail"][0]["msg"] == (
+        "Input should be a valid UUID, invalid length: "
+        "expected length 32 for simple format, found 3"
+    )
+    assert data["detail"][0]["type"] == "uuid_parsing"
 
 
 def test_get_device_with_nonexistent_device_id(client: TestClient) -> None:
@@ -183,8 +186,11 @@ def test_get_all_devices_with_invalid_limit(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid integer"
-    assert data["detail"][0]["type"] == "type_error.integer"
+    assert (
+        data["detail"][0]["msg"]
+        == "Input should be a valid integer, unable to parse string as an integer"
+    )
+    assert data["detail"][0]["type"] == "int_parsing"
 
 
 def test_get_all_devices_with_offset(client: TestClient) -> None:
@@ -224,8 +230,11 @@ def test_get_all_devices_with_invalid_offset(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid integer"
-    assert data["detail"][0]["type"] == "type_error.integer"
+    assert (
+        data["detail"][0]["msg"]
+        == "Input should be a valid integer, unable to parse string as an integer"
+    )
+    assert data["detail"][0]["type"] == "int_parsing"
 
 
 def test_get_all_devices_with_limit_and_offset(client: TestClient) -> None:
@@ -265,7 +274,13 @@ def test_get_all_devices_with_invalid_limit_and_offset(client: TestClient) -> No
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid integer"
-    assert data["detail"][0]["type"] == "type_error.integer"
-    assert data["detail"][1]["msg"] == "value is not a valid integer"
-    assert data["detail"][1]["type"] == "type_error.integer"
+    assert (
+        data["detail"][0]["msg"]
+        == "Input should be a valid integer, unable to parse string as an integer"
+    )
+    assert data["detail"][0]["type"] == "int_parsing"
+    assert (
+        data["detail"][1]["msg"]
+        == "Input should be a valid integer, unable to parse string as an integer"
+    )
+    assert data["detail"][1]["type"] == "int_parsing"

--- a/backend/tests/api/public/pulse/test_views.py
+++ b/backend/tests/api/public/pulse/test_views.py
@@ -73,8 +73,11 @@ def test_create_pulse_with_invalid_delays(client: TestClient, device_id: UUID) -
     pulse_data = pulse_response.json()
 
     assert pulse_response.status_code == 422
-    assert pulse_data["detail"][0]["msg"] == "value is not a valid float"
-    assert pulse_data["detail"][0]["type"] == "type_error.float"
+    assert (
+        pulse_data["detail"][0]["msg"]
+        == "Input should be a valid number, unable to parse string as a number"
+    )
+    assert pulse_data["detail"][0]["type"] == "float_parsing"
 
 
 def test_create_pulse_with_invalid_signal(client: TestClient, device_id: UUID) -> None:
@@ -89,8 +92,11 @@ def test_create_pulse_with_invalid_signal(client: TestClient, device_id: UUID) -
     pulse_data = pulse_response.json()
 
     assert pulse_response.status_code == 422
-    assert pulse_data["detail"][0]["msg"] == "value is not a valid float"
-    assert pulse_data["detail"][0]["type"] == "type_error.float"
+    assert (
+        pulse_data["detail"][0]["msg"]
+        == "Input should be a valid number, unable to parse string as a number"
+    )
+    assert pulse_data["detail"][0]["type"] == "float_parsing"
 
 
 def test_create_pulse_with_invalid_integration_time(
@@ -108,8 +114,11 @@ def test_create_pulse_with_invalid_integration_time(
     pulse_data = pulse_response.json()
 
     assert pulse_response.status_code == 422
-    assert pulse_data["detail"][0]["msg"] == "value is not a valid integer"
-    assert pulse_data["detail"][0]["type"] == "type_error.integer"
+    assert (
+        pulse_data["detail"][0]["msg"]
+        == "Input should be a valid integer, unable to parse string as an integer"
+    )
+    assert pulse_data["detail"][0]["type"] == "int_parsing"
 
 
 def test_create_pulse_with_nonexistent_device_id(client: TestClient) -> None:
@@ -138,8 +147,11 @@ def test_create_pulse_with_invalid_device_id(
     )
 
     assert pulse_response.status_code == 422
-    assert pulse_response.json()["detail"][0]["msg"] == "value is not a valid uuid"
-    assert pulse_response.json()["detail"][0]["type"] == "type_error.uuid"
+    assert pulse_response.json()["detail"][0]["msg"] == (
+        "Input should be a valid UUID, invalid length: "
+        "expected length 32 for simple format, found 1"
+    )
+    assert pulse_response.json()["detail"][0]["type"] == "uuid_parsing"
 
 
 def test_create_pulse_with_invalid_creation_time(
@@ -155,8 +167,11 @@ def test_create_pulse_with_invalid_creation_time(
     )
 
     assert pulse_response.status_code == 422
-    assert pulse_response.json()["detail"][0]["msg"] == "invalid datetime format"
-    assert pulse_response.json()["detail"][0]["type"] == "value_error.datetime"
+    assert (
+        pulse_response.json()["detail"][0]["msg"]
+        == "Input should be a valid datetime, input is too short"
+    )
+    assert pulse_response.json()["detail"][0]["type"] == "datetime_parsing"
 
 
 def test_get_pulse_with_invalid_pulse_id(client: TestClient) -> None:
@@ -164,8 +179,11 @@ def test_get_pulse_with_invalid_pulse_id(client: TestClient) -> None:
     data = response.json()
 
     assert response.status_code == 422
-    assert data["detail"][0]["msg"] == "value is not a valid uuid"
-    assert data["detail"][0]["type"] == "type_error.uuid"
+    assert data["detail"][0]["msg"] == (
+        "Input should be a valid UUID, invalid length: "
+        "expected length 32 for simple format, found 3"
+    )
+    assert data["detail"][0]["type"] == "uuid_parsing"
 
 
 def test_get_pulse_with_nonexistent_pulse_id(client: TestClient) -> None:


### PR DESCRIPTION
SQLModel has been updated to support Pydantic 2. This means that the newest FastAPI version is supported as well. Dependencies have thus been updated.

This required a few Pydantic-based changes:
* Use ´field_validator´ instead of ´validator´
* Use pydantic-settings' ´BaseSettings´, which required typed attributes
* Rewrite tests, as Pydantic error messages have gotten more verbose

 as well as a few SQLModel changes
* Use ´model_validate()´ instead of ´from_orm()´
* Use ´model_dump()´ instead of ´dict()´