### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [black, ruff, mypy, pytest, vitest]
+        test: [ruff_check, ruff_format, mypy, pytest, vitest]
     needs: backend-image-check-and-push
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ you may create a file `.vscode/settings.json`, and populate it like so:
 ```json
 {
     "python.analysis.extraPaths": ["./backend"],
-    "black-formatter.args": [
-        "--config",
-        "./backend/pyproject.toml"
-    ],
-    "black-formatter.importStrategy": "fromEnvironment",
     "ruff.format.args": [
         "--config",
         "./backend/pyproject.toml"

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 This is the TeraStore API.
 
 This project uses [`FastAPI`](https://fastapi.tiangolo.com) and `Python 3.11`.
-It is typed using [`mypy`](https://www.mypy-lang.org), linted with [`Ruff`](https://docs.astral.sh/ruff/), formatted with [`Black`](https://black.readthedocs.io/en/stable/) and tested with [`pytest`](https://docs.pytest.org/).
+It is typed using [`mypy`](https://www.mypy-lang.org), linted and formatted with [`Ruff`](https://docs.astral.sh/ruff/), and tested with [`pytest`](https://docs.pytest.org/).
 
 We use [`Poetry`](https://python-poetry.org) to install the project and manage dependencies.
 

--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -108,7 +108,7 @@ def add_attr(
     # Now, add the new EAV attribute
     pulse_attrs_class = get_pulse_attrs_class(AttrDataType(kv_pair.data_type))
 
-    db.add(pulse_attrs_class(**kv_pair.model_dump(), pulse_id=pulse_id))
+    db.add(pulse_attrs_class(**kv_pair.model_dump(warnings="none"), pulse_id=pulse_id))
     db.commit()
 
 

--- a/backend/api/public/attrs/crud.py
+++ b/backend/api/public/attrs/crud.py
@@ -73,7 +73,7 @@ def add_attrs(
     for pulse_attrs in pulses_attrs:
         for attrs in pulse_attrs.pulse_attributes:
             attr_cls = get_pulse_attrs_class(attrs.data_type)
-            db.add(attr_cls(pulse_id=pulse_attrs.pulse_id, **attrs.dict()))
+            db.add(attr_cls(pulse_id=pulse_attrs.pulse_id, **attrs.model_dump()))
 
     # Finally, commit all changes
     db.commit()
@@ -108,7 +108,7 @@ def add_attr(
     # Now, add the new EAV attribute
     pulse_attrs_class = get_pulse_attrs_class(AttrDataType(kv_pair.data_type))
 
-    db.add(pulse_attrs_class(**kv_pair.dict(), pulse_id=pulse_id))
+    db.add(pulse_attrs_class(**kv_pair.model_dump(), pulse_id=pulse_id))
     db.commit()
 
 
@@ -242,9 +242,11 @@ def create_filter_query(
     kv_data_type: str,
 ) -> SelectOfScalar[UUID]:
     if kv_data_type == AttrDataType.STRING.value:
-        return create_attr_str_filter_query(PulseAttrsStrFilter(**kv_pair.dict()))
+        return create_attr_str_filter_query(PulseAttrsStrFilter(**kv_pair.model_dump()))
     if kv_data_type == AttrDataType.FLOAT.value:
-        return create_attr_float_filter_query(PulseAttrsFloatFilter(**kv_pair.dict()))
+        return create_attr_float_filter_query(
+            PulseAttrsFloatFilter(**kv_pair.model_dump())
+        )
 
     error_str = "kv_pair must be of type PulseAttrsStrFilter or PulseAttrsFloatFilter"
     raise TypeError(error_str)

--- a/backend/api/public/auth/auth_handler.py
+++ b/backend/api/public/auth/auth_handler.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 from typing import Any
 
+import jwt
 from fastapi import Depends, Response
 from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError, jwt
 from sqlmodel import Session
 
 from api.config import get_auth_settings
@@ -39,14 +39,14 @@ def authenticate_user_token(
 ) -> User:
     try:
         payload = jwt.decode(
-            token,
-            auth_settings.SECRET_KEY,
+            jwt=token,
+            key=auth_settings.SECRET_KEY,
             algorithms=[auth_settings.ALGORITHM],
         )
         email = payload.get("sub")
         if email is None:
             raise CredentialsIncorrectError
-    except JWTError as e:
+    except jwt.DecodeError as e:
         raise CredentialsIncorrectError from e
     return get_user(email=email, db=db)
 
@@ -59,9 +59,7 @@ def create_token(
     to_encode = data.copy()
     to_encode.update({"exp": expires})
     return jwt.encode(
-        to_encode,
-        auth_settings.SECRET_KEY,
-        algorithm=algorithm,
+        payload=to_encode, key=auth_settings.SECRET_KEY, algorithm=algorithm
     )
 
 

--- a/backend/api/public/auth/helpers.py
+++ b/backend/api/public/auth/helpers.py
@@ -1,11 +1,11 @@
-from passlib.context import CryptContext
-
-pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+import bcrypt
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    return bcrypt.checkpw(
+        password=plain_password.encode(), hashed_password=hashed_password.encode()
+    )
 
 
 def get_password_hash(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password=password.encode(), salt=bcrypt.gensalt()).decode()

--- a/backend/api/public/device/models.py
+++ b/backend/api/public/device/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Self
 from uuid import UUID, uuid4
 
+from pydantic import ConfigDict
 from sqlmodel import Field, SQLModel
 
 
@@ -35,8 +36,7 @@ class DeviceCreate(DeviceBase):
     it is only here for FastAPI documentation purposes.
     """
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")  # type: ignore[assignment]
 
     @classmethod
     def create_mock(cls: type[DeviceCreate], friendly_name: str) -> DeviceCreate:

--- a/backend/api/public/pulse/crud.py
+++ b/backend/api/public/pulse/crud.py
@@ -103,6 +103,7 @@ def read_pulses_with_ids(
     pulse_attrs = read_pulse_attrs(pulse_ids=ids, db=db, check_pulses_exist=False)
 
     # Delete the entries from the temporary table again
+    # This raises a warning, but SQLModel's alternative solution does not work
     db.query(TemporaryPulseIdTable).delete()
     db.commit()
     return [

--- a/backend/api/utils/exception_handlers.py
+++ b/backend/api/utils/exception_handlers.py
@@ -1,22 +1,12 @@
-from fastapi import Request
+from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette import status
-
-from api.utils.exceptions import (
-    AttrDataTypeDoesNotExistError,
-    AttrDataTypeExistsError,
-    AttrKeyDoesNotExistError,
-    CredentialsIncorrectError,
-    DeviceNotFoundError,
-    PulseColumnNonexistentError,
-    PulseNotFoundError,
-)
 
 
 async def pulse_not_found_exception_handler(
     _request: Request,
-    exc: PulseNotFoundError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": str(exc)},
@@ -25,8 +15,8 @@ async def pulse_not_found_exception_handler(
 
 async def pulse_column_nonexistent_exception_handler(
     _request: Request,
-    exc: PulseColumnNonexistentError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": str(exc)},
@@ -35,8 +25,8 @@ async def pulse_column_nonexistent_exception_handler(
 
 async def device_not_found_exception_handler(
     _request: Request,
-    exc: DeviceNotFoundError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": str(exc)},
@@ -45,8 +35,8 @@ async def device_not_found_exception_handler(
 
 async def attr_data_type_exists_exception_handler(
     _request: Request,
-    exc: AttrDataTypeExistsError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
         content={"detail": str(exc)},
@@ -55,8 +45,8 @@ async def attr_data_type_exists_exception_handler(
 
 async def attr_key_does_not_exist_exception_handler(
     _request: Request,
-    exc: AttrKeyDoesNotExistError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": str(exc)},
@@ -65,8 +55,8 @@ async def attr_key_does_not_exist_exception_handler(
 
 async def attr_data_type_does_not_exist_exception_handler(
     _request: Request,
-    exc: AttrDataTypeDoesNotExistError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": str(exc)},
@@ -76,7 +66,7 @@ async def attr_data_type_does_not_exist_exception_handler(
 async def username_or_password_incorrect_exception_handler(
     _request: Request,
     exc: Exception,
-) -> JSONResponse:
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_401_UNAUTHORIZED,
         content={"detail": str(exc)},
@@ -86,7 +76,7 @@ async def username_or_password_incorrect_exception_handler(
 async def username_already_exists_exception_handler(
     _request: Request,
     exc: Exception,
-) -> JSONResponse:
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_409_CONFLICT,
         content={"detail": str(exc)},
@@ -95,8 +85,8 @@ async def username_already_exists_exception_handler(
 
 async def credentials_incorrect_exception_handler(
     _request: Request,
-    exc: CredentialsIncorrectError,
-) -> JSONResponse:
+    exc: Exception,
+) -> Response:
     return JSONResponse(
         status_code=status.HTTP_401_UNAUTHORIZED,
         content={"detail": str(exc)},

--- a/backend/api/utils/helpers.py
+++ b/backend/api/utils/helpers.py
@@ -70,6 +70,6 @@ def get_model_columns_from_names(
     except AttributeError as e:
         raise PulseColumnNonexistentError(
             wanted=str(e),
-            columns=list(model.schema()["properties"]),
+            columns=list(model.model_json_schema()["properties"]),
         ) from e
     return fields

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,30 +10,27 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-  "fastapi[all]==0.104.1",
-  "sqlmodel==0.0.14",
-  "pydantic==2.5.2",
-  "pydantic-settings==2.1.0",
+  "fastapi[all]==0.111.1",
+  "sqlmodel==0.0.19",
+  "pydantic==2.8.2",
+  "pydantic-settings==2.3.4",
   "psycopg2-binary==2.9.9",
   "python-jose[cryptography]==3.3.0",
-  "passlib[argon2]==1.7.4",
+  "bcrypt==4.1.3",
 ]
 
 [project.optional-dependencies]
 test = [
-  "mypy==1.7.1",
-  "black==23.11.0",
-  "ruff==0.1.7",
+  "mypy>=1.10,<1.11",
+  "ruff>=0.5,<0.6",
   "pytest==7.4.3",
   "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
   "types-python-jose==3.3.4.8",
-  "types-passlib==1.7.7.13",
 ]
 dev = [
-  "mypy==1.7.1",
-  "black==23.11.0",
-  "ruff==0.1.7",
+  "mypy>=1.10,<1.11",
+  "ruff>=0.5,<0.6",
   "pytest==7.4.3",
   "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
@@ -65,9 +62,9 @@ warn_required_dynamic_aliases = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
-select = ["ALL"]
-ignore = [
+target-version = "py312"
+lint.select = ["ALL"]
+lint.ignore = [
   "D100", # allow undocumented public modules
   "D101", # allow undocumented public class
   "D102", # allow undocumented public method
@@ -77,9 +74,12 @@ ignore = [
   "D107", # allow undocumented public __init__
   "D203", # allow 0 black lines before class docstring
   "D213", # allow multiline docstring to start on first line
+  "UP040", # "type" keyword not implemented in mypy yet
+  "ISC001", # ruff recommends disabling when using the formatter
+  "COM812" # ruff recommends disabling when using the formatter
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # from https://github.com/astral-sh/ruff/issues/4368
 "tests/**/*.py" = [
   "S101",    # asserts allowed in tests...
@@ -103,11 +103,6 @@ ignore = [
 ]
 "api/main.py" = ["ARG001"] # Unused function args
 
-[tool.black]
-line-length = 88
-target-version = ["py311"]
-# TODO: the below doesn't work...
-include = '(?:tests|api)\/.*\.pyi?$'
 
 [tool.coverage.run]
 omit = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pydantic==2.8.2",
   "pydantic-settings==2.3.4",
   "psycopg2-binary==2.9.9",
-  "python-jose[cryptography]==3.3.0",
+  "PyJWT==2.8.0",
   "bcrypt==4.1.3",
 ]
 
@@ -26,7 +26,6 @@ test = [
   "pytest==7.4.3",
   "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
-  "types-python-jose==3.3.4.8",
 ]
 dev = [
   "mypy>=1.10,<1.11",
@@ -34,8 +33,6 @@ dev = [
   "pytest==7.4.3",
   "types-psycopg2==2.9.21.19",
   "pytest-cov==4.1.0",
-  "types-python-jose==3.3.4.8",
-  "types-passlib==1.7.7.13",
 ]
 
 [tool.mypy]

--- a/backend/tests/api/public/auth/test_views.py
+++ b/backend/tests/api/public/auth/test_views.py
@@ -19,6 +19,15 @@ def test_login_with_wrong_password(client: TestClient) -> None:
     assert data["detail"] == "Email or password is incorrect."
 
 
+def test_login_with_wrong_username(client: TestClient) -> None:
+    user_payload = {"username": "wrong_username@admin", "password": "admin"}
+    response = client.post("/auth/login", data=user_payload)
+    data = response.json()
+
+    assert response.status_code == 401
+    assert data["detail"] == "Email or password is incorrect."
+
+
 def test_get_all_users(client: TestClient) -> None:
     user_payload = {"email": "admin2@admin", "password": "admin"}
     response = client.post("/auth/signup", json=user_payload)

--- a/backend/tests/api/public/pulse/test_views.py
+++ b/backend/tests/api/public/pulse/test_views.py
@@ -169,9 +169,9 @@ def test_create_pulse_with_invalid_creation_time(
     assert pulse_response.status_code == 422
     assert (
         pulse_response.json()["detail"][0]["msg"]
-        == "Input should be a valid datetime, input is too short"
+        == "Input should be a valid datetime or date, input is too short"
     )
-    assert pulse_response.json()["detail"][0]["type"] == "datetime_parsing"
+    assert pulse_response.json()["detail"][0]["type"] == "datetime_from_date_parsing"
 
 
 def test_get_pulse_with_invalid_pulse_id(client: TestClient) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,8 @@ def setup_db() -> Generator[Session, None, None]:
     settings = get_settings()
     engine = create_engine(settings.DATABASE_URL, echo=True)
 
+    # In case of a dirty DB, drop all tables and recreate them for consistent testing
+    drop_tables(engine)
     create_db_and_tables(engine)
 
     user = UserCreate(

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: terastore-dev
 
 services:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: terastore-prod
 
 services:

--- a/docker-compose-test-local.yml
+++ b/docker-compose-test-local.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend-test:
     build:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: terastore-test
 
 services:

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -60,8 +60,8 @@ else
   echo -e "${YELLOW}Docker start succeeded. Using cached images...${NC}"
 fi
 
-run_test ./scripts/run_black.sh
-run_test ./scripts/run_ruff.sh
+run_test ./scripts/run_ruff_check.sh
+run_test ./scripts/run_ruff_format.sh
 run_test ./scripts/run_mypy.sh
 run_test ./scripts/run_pytest.sh
 run_test ./scripts/run_vitest.sh

--- a/scripts/run_black.sh
+++ b/scripts/run_black.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "Running Black..."
-docker compose -f ./docker-compose-test.yml exec -T backend-test black --check . || exit 1

--- a/scripts/run_ruff.sh
+++ b/scripts/run_ruff.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "Running Ruff..."
-docker compose -f ./docker-compose-test.yml exec -T backend-test ruff check . || exit 1

--- a/scripts/run_ruff_check.sh
+++ b/scripts/run_ruff_check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Running Ruff check..."
+docker compose -f ./docker-compose-test.yml exec -T backend-test ruff check api || exit 1

--- a/scripts/run_ruff_format.sh
+++ b/scripts/run_ruff_format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Running Ruff check..."
+docker compose -f ./docker-compose-test.yml exec -T backend-test ruff format api --check || exit 1


### PR DESCRIPTION
This MR solves general house-keeping tasks. Specifically, it
- replaces `black` with `ruff` format like in our other projects
- bumps SQLModel, ruff and mypy to their latest versions
- changes code to comply with newest packages (e.g. by removing deprecated methods)
- replaces `passlib` with `bcrypt`, since `passlib` is deprecated and slated for removal in python 3.13.
- replaces `python-jose` with `PyJWT` since `python-jose` uses deprecated code and is no longer maintained.

Closes #106 